### PR TITLE
Add missing quote marks in cleanup_tables.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16340,7 +16340,7 @@ cleanup_tables ()
        "        AND subject NOT IN (SELECT id FROM roles_trash));");
 
   sql ("DELETE FROM permissions_get_tasks"
-       " WHERE user NOT IN (SELECT id FROM users);");
+       " WHERE \"user\" NOT IN (SELECT id FROM users);");
 }
 
 /**


### PR DESCRIPTION
The last statement was missing quote marks around the column name
 "user", which are required for PostgreSQL.