### PR TITLE
Test if credential is used by TippingPoint alerts.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41277,6 +41277,7 @@ credential_in_use (credential_t credential)
            || sql_int ("SELECT count (*) FROM alert_method_data"
                        " WHERE (name = 'scp_credential'"
                        "        OR name = 'smb_credential'"
+                       "        OR name = 'tp_sms_credential'"
                        "        OR name = 'verinice_server_credential')"
                        " AND data = '%s'",
                        uuid));
@@ -41311,6 +41312,7 @@ trash_credential_in_use (credential_t credential)
            || sql_int ("SELECT count (*) FROM alert_method_data_trash"
                        " WHERE (name = 'scp_credential'"
                        "        OR name = 'smb_credential'"
+                       "        OR name = 'tp_sms_credential'"
                        "        OR name = 'verinice_server_credential')"
                        " AND data = '%s'",
                        uuid));


### PR DESCRIPTION
When checking if a credential is in use, also look for alert method data
for the TippingPoint SMS method.