### PR TITLE
Remove permissions_get_tasks in cleanup_tables.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -16881,9 +16881,6 @@ cleanup_tables ()
        "    OR (subject_type = 'role'"
        "        AND subject_location = " G_STRINGIFY (LOCATION_TRASH)
        "        AND subject NOT IN (SELECT id FROM roles_trash));");
-
-  sql ("DELETE FROM permissions_get_tasks"
-       " WHERE \"user\" NOT IN (SELECT id FROM users);");
 }
 
 /**


### PR DESCRIPTION
One of the SQL statements for cleaning up the permissions was removed
because it was referring to the table permissions_get_tasks which only
exists in the master branch.