### PR TITLE
Add attribute get_counts to GET_RESULTS

### DIFF
--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -16998,6 +16998,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Whether to include additional details of the results</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>get_counts</name>
+        <summary>Whether to include result counts</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -17015,7 +17020,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <e>filters</e>
         <e>sort</e>
         <e>results</e>
-        <e>result_count</e>
+        <o><e>result_count</e></o>
       </pattern>
       <ele>
         <name>result</name>


### PR DESCRIPTION
This allows GSA to skip the result counts when they are not needed, because
counting can be slow with bigger databases.