### PR TITLE
Add attribute get_counts to GET_RESULTS

### DIFF
--- a/src/omp.c
+++ b/src/omp.c
@@ -2860,6 +2860,7 @@ typedef struct
   char *task_id;         ///< Task associated with results.
   int notes_details;     ///< Boolean.  Whether to include details of above.
   int overrides_details; ///< Boolean.  Whether to include details of above.
+  int get_counts;        ///< Boolean.  Whether to include result counts.
 } get_results_data_t;
 
 /**
@@ -6196,6 +6197,7 @@ buffer_get_filter_xml (GString *msg, const char* type,
  *
  * @param[in]  type                  Type.
  * @param[in]  get                   GET data.
+ * @param[in]  get_counts            Include counts.
  * @param[in]  count                 Page count.
  * @param[in]  filtered              Filtered count.
  * @param[in]  full                  Full count.
@@ -6203,9 +6205,10 @@ buffer_get_filter_xml (GString *msg, const char* type,
  * @param[in]  write_to_client_data  Data for write_to_client.
  */
 int
-send_get_end (const char *type, get_data_t *get, int count, int filtered,
-              int full, int (*write_to_client) (const char *, void*),
-              void* write_to_client_data)
+send_get_end_internal (const char *type, get_data_t *get, int get_counts,
+                       int count, int filtered, int full,
+                       int (*write_to_client) (const char *, void*),
+                       void* write_to_client_data)
 {
   gchar *sort_field, *filter;
   int first, max, sort_order;
@@ -6296,23 +6299,26 @@ send_get_end (const char *type, get_data_t *get, int count, int filtered,
                             "<sort>"
                             "<field>%s<order>%s</order></field>"
                             "</sort>"
-                            "<%s start=\"%i\" max=\"%i\"/>"
-                            "<%s_count>"
-                            "%i"
-                            "<filtered>%i</filtered>"
-                            "<page>%i</page>"
-                            "</%s_count>"
-                            "</get_%s_response>",
+                            "<%s start=\"%i\" max=\"%i\"/>",
                             sort_field,
                             sort_order ? "ascending" : "descending",
                             type_many->str,
                             first,
-                            max,
-                            type,
-                            full,
-                            filtered,
-                            count,
-                            type,
+                            max);
+  if (get_counts)
+    buffer_xml_append_printf (msg,
+                              "<%s_count>"
+                              "%i"
+                              "<filtered>%i</filtered>"
+                              "<page>%i</page>"
+                              "</%s_count>",
+                              type,
+                              full,
+                              filtered,
+                              count,
+                              type);
+  buffer_xml_append_printf (msg,
+                            "</get_%s_response>",
                             type_many->str);
   g_string_free (type_many, TRUE);
   g_free (sort_field);
@@ -6325,6 +6331,46 @@ send_get_end (const char *type, get_data_t *get, int count, int filtered,
     }
   g_string_free (msg, TRUE);
   return 0;
+}
+
+/**
+ * @brief Send end of GET response.
+ *
+ * @param[in]  type                  Type.
+ * @param[in]  get                   GET data.
+ * @param[in]  count                 Page count.
+ * @param[in]  filtered              Filtered count.
+ * @param[in]  full                  Full count.
+ * @param[in]  write_to_client       Function that sends to clients.
+ * @param[in]  write_to_client_data  Data for write_to_client.
+ */
+int
+send_get_end (const char *type, get_data_t *get, int count, int filtered,
+              int full, int (*write_to_client) (const char *, void*),
+              void* write_to_client_data)
+{
+  return send_get_end_internal (type, get, 1, count, filtered, full,
+                                write_to_client, write_to_client_data);
+}
+
+/**
+ * @brief Send end of GET response, skipping result counts.
+ *
+ * @param[in]  type                  Type.
+ * @param[in]  get                   GET data.
+ * @param[in]  count                 Page count.
+ * @param[in]  filtered              Filtered count.
+ * @param[in]  full                  Full count.
+ * @param[in]  write_to_client       Function that sends to clients.
+ * @param[in]  write_to_client_data  Data for write_to_client.
+ */
+int
+send_get_end_no_counts (const char *type, get_data_t *get,
+                        int (*write_to_client) (const char *, void*),
+                        void* write_to_client_data)
+{
+  return send_get_end_internal (type, get, 0, 0, 0, 0, write_to_client,
+                                write_to_client_data);
 }
 
 /**
@@ -7531,6 +7577,12 @@ omp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
               get_results_data->overrides_details = strcmp (attribute, "0");
             else
               get_results_data->overrides_details = 0;
+
+            if (find_attribute (attribute_names, attribute_values,
+                                "get_counts", &attribute))
+              get_results_data->get_counts = strcmp (attribute, "0");
+            else
+              get_results_data->get_counts = 1;
 
             set_client_state (CLIENT_GET_RESULTS);
           }
@@ -17508,7 +17560,7 @@ handle_get_results (omp_parser_t *omp_parser, GError **error)
       const char* filter;
       iterator_t results;
       int notes, overrides;
-      int count, filtered, ret, first;
+      int count, ret, first;
 
       if (get_results_data->get.filt_id
           && strcmp (get_results_data->get.filt_id, "0"))
@@ -17593,12 +17645,32 @@ handle_get_results (omp_parser_t *omp_parser, GError **error)
       manage_filter_controls (get_results_data->get.filter,
                               &first, NULL, NULL, NULL);
 
-      filtered = get_results_data->get.id
-                  ? 1 : result_count (&get_results_data->get,
-                                      0 /* No report */,
-                                      NULL /* No host */);
+      if (get_results_data->get_counts)
+        {
+          int filtered;
 
-      SEND_GET_END ("result", &get_results_data->get, count, filtered);
+          filtered = get_results_data->get.id
+                      ? 1 : result_count (&get_results_data->get,
+                                          0 /* No report */,
+                                          NULL /* No host */);
+
+          if (send_get_end ("result", &get_results_data->get, count, filtered,
+                            resource_count ("result", &get_results_data->get),
+                            omp_parser->client_writer,
+                            omp_parser->client_writer_data))
+            {
+              error_send_to_client (error);
+              return;
+            }
+        }
+      else if (send_get_end_no_counts ("result",
+                                       &get_results_data->get,
+                                       omp_parser->client_writer,
+                                       omp_parser->client_writer_data))
+        {
+          error_send_to_client (error);
+          return;
+        }
     }
 
   get_results_data_reset (get_results_data);

--- a/src/schema_formats/XML/OMP.xml.in
+++ b/src/schema_formats/XML/OMP.xml.in
@@ -16962,6 +16962,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Whether to include additional details of the results</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>get_counts</name>
+        <summary>Whether to include result counts</summary>
+        <type>boolean</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -16979,7 +16984,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <e>filters</e>
         <e>sort</e>
         <e>results</e>
-        <e>result_count</e>
+        <o><e>result_count</e></o>
       </pattern>
       <ele>
         <name>result</name>


### PR DESCRIPTION
This allows GSA to skip the result counts when they are not needed, because
counting can be slow with bigger databases.