### PR TITLE
Return from report_severity_data if report is 0.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24426,6 +24426,9 @@ report_severity_data (report_t report, const char *host,
   gchar *filter, *value;
   int apply_overrides, autofp;
 
+  if (report == 0)
+    return;
+
   if (get->filt_id && strcmp (get->filt_id, FILT_ID_NONE))
     {
       filter = filter_term (get->filt_id);


### PR DESCRIPTION
In the report_severity_data return immediately if report is 0 because
the iterator expects a non-zero report and there would be no results
to count.
The function can be called from SQL functions when using the SQLite
back-end getting tasks without any reports.