### PR TITLE
Remove permissions control into init_task_schedule_iterator

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48585,26 +48585,13 @@ int
 init_task_schedule_iterator (iterator_t* iterator)
 {
   int ret;
-  gchar *task_clause, *schedule_clause;
   get_data_t get;
-  array_t *permissions;
 
   ret = sql_begin_immediate_giveup ();
   if (ret)
     return ret;
 
   get.trash = 0;
-  permissions = make_array ();
-  array_add (permissions, g_strdup ("start_task"));
-  task_clause = acl_where_owned_user ("", "users.id", "task", &get, 1,
-                                      "any", 0, permissions);
-  array_free (permissions);
-
-  permissions = make_array ();
-  array_add (permissions, g_strdup ("get_schedules"));
-  schedule_clause = acl_where_owned_user ("", "users.id", "schedule", &get, 1,
-                                          "any", 0, permissions);
-  array_free (permissions);
 
   init_iterator (iterator,
                  "SELECT tasks.id, tasks.uuid,"
@@ -48624,8 +48611,6 @@ init_task_schedule_iterator (iterator_t* iterator)
                  "          (users.id = tasks.owner) DESC,"
                  "          (users.id = schedules.owner) DESC;");
 
-  g_free (task_clause);
-  g_free (schedule_clause);
   return 0;
 }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48618,16 +48618,11 @@ init_task_schedule_iterator (iterator_t* iterator)
                  " FROM tasks, schedules, users"
                  " WHERE tasks.schedule = schedules.id"
                  " AND tasks.hidden = 0"
-                 /* And a user may run the task. */
-                 " AND %s"
-                 /* And the same user has access to the schedule. */
-                 " AND %s"
+                 " AND (tasks.owner = (users.id))"
                  /* Sort by task and prefer owner of task or schedule as user */
                  " ORDER BY tasks.id,"
                  "          (users.id = tasks.owner) DESC,"
-                 "          (users.id = schedules.owner) DESC;",
-                 task_clause,
-                 schedule_clause);
+                 "          (users.id = schedules.owner) DESC;");
 
   g_free (task_clause);
   g_free (schedule_clause);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48585,13 +48585,10 @@ int
 init_task_schedule_iterator (iterator_t* iterator)
 {
   int ret;
-  get_data_t get;
 
   ret = sql_begin_immediate_giveup ();
   if (ret)
     return ret;
-
-  get.trash = 0;
 
   init_iterator (iterator,
                  "SELECT tasks.id, tasks.uuid,"


### PR DESCRIPTION
Hi guys,

I noticed that as I increased the number of scheduled tasks the omp commands were delayed very long.
I searched and found that the init_task_schedule_iterator function that runs every 10 seconds and check the tasks that need to run (these that have a schedule), it's taking a long time to complete, and blocks all other sql queries as it became Lock on DB.

Every time that you create a new scheduled task, the time of this query increase with result to stucks whole the system.

**[Postgres EXPLAIN ANALYZE]** 
Returns a table with 33 rows witch in fact are only 5 rows that are being repeated continuously
> Sort  (cost=3225466.49..3225502.24 rows=14300 width=129) (actual time=7652.611..7652.665 rows=33 loops=1)

So I tried to remove the extra checks on whether the user who created the task and the schedule has the permissions to run it.
That's what brought results with incredible differences in speeds, as the locked query is finishing up very fast compared to before.

The reason why I create a pull request is that I do not find any reason to check permissions since the resources (tasks & schedules) already have been created, the system must be able to run the task.
It's just an automatic process that a user don't needs run by clicking the run task button.

**[Postgres EXPLAIN ANALYZE]** 
> Sort  (cost=40.29..40.40 rows=46 width=129) (actual time=2.207..2.212 rows=5 loops=1)

If my way is wrong, please dismiss this request, but in my opinion it's a problem that should somehow be solved. Perhaps by optimizing this sql query, I don't know...

\* I've been running this code on my system for about three weeks, and it seems to be all right.

