### PR TITLE
Assume "scanner loading" if a message is empty in SCANNER_INIT_SENT_VERSION case.

### DIFF
--- a/src/gmpd.c
+++ b/src/gmpd.c
@@ -1017,8 +1017,10 @@ serve_gmp (gvm_connection_t *client_connection, const gchar *database,
             /* to_scanner buffer still full. */
             g_debug ("   scanner input stalled\n");
           else
-            /* Programming error. */
-            assert (ret == 0);
+            {
+              /* Programming error. */
+              assert (ret == 0 || ret == 5);
+            }
         }
 
       if (process_gmp_change () == -1)

--- a/src/otp.c
+++ b/src/otp.c
@@ -812,6 +812,11 @@ process_otp_scanner_input ()
                      "Waiting for scanner to load: No information provided. (Message: %s)\n", messages);
             return 3;
           }
+        /* If message is empty we assume the scanner is still loading. */
+        if (!*messages)
+          {
+            return 5;
+          }
         if (from_scanner_end - from_scanner_start < ver_len)
           {
             /* Need more input. */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -876,12 +876,28 @@ openvas_scanner_set_certs (const char *ca_pub, const char *key_pub,
 int
 openvas_scanner_is_loading ()
 {
-  /* Add little delay in case we read before scanner write, as the socket is
-   * non-blocking. */
-  gvm_usleep (500000);
-  openvas_scanner_read ();
-
-  if (process_otp_scanner_input (NULL) == 3)
-    return 1;
-  return 0;
+  int attempts = 5;
+  int ret = 0;
+  while (attempts >= 0)
+    {
+      /* Add little delay in case we read before scanner write, as the socket is
+       * non-blocking. */
+      attempts = attempts - 1;
+      gvm_usleep (500000);
+      openvas_scanner_read ();
+      
+      switch (process_otp_scanner_input (NULL))
+        {
+          case 3:
+            /* Still loading. */
+            return 1;
+          case 5:
+            /* Empty message. Try again. */
+            ret = 1;
+            break;
+          default:
+            return 0;
+        }
+    }
+  return ret;
 }


### PR DESCRIPTION
* src/otp.c (process_otp_scanner_input) Assume that the scanner is still loading if there is an empty message in the SCANNER_INIT_SENT_VERSION case, this case return 5.

* src/gmpd.c (serve_gmp): Handle the case 5.

* src/scanner.c (openvas_scanner_is_loading): Do up to 5 attempts of 0.5sec to get
  a message in case we read before scanner write.