### PR TITLE
Backport PR #34.

### DIFF
--- a/src/ompd.c
+++ b/src/ompd.c
@@ -1017,8 +1017,10 @@ serve_omp (openvas_connection_t *client_connection, const gchar *database,
             /* to_scanner buffer still full. */
             g_debug ("   scanner input stalled\n");
           else
-            /* Programming error. */
-            assert (ret == 0);
+            {
+              /* Programming error. */
+              assert (ret == 0 || ret == 5);
+            }
         }
 
       if (process_omp_change () == -1)

--- a/src/otp.c
+++ b/src/otp.c
@@ -823,6 +823,11 @@ process_otp_scanner_input (void (*progress) ())
                      "Waiting for scanner to load: No information provided. (Message: %s)\n", messages);
             return 3;
           }
+        /* If message is empty we assume the scanner is still loading. */
+        if (!*messages)
+          {
+            return 5;
+          }
         if (from_scanner_end - from_scanner_start < ver_len)
           {
             /* Need more input. */


### PR DESCRIPTION
With adjustments due to code changes.

Assume "scanner loading" if a message is empty in SCANNER_INIT_SENT_VERSION case.
This avoid that started tasks during the NVTs load up hang in "Requested" status.