### PR TITLE
Add validation for fields in modify_credential.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41907,7 +41907,10 @@ copy_credential (const char* name, const char* comment,
  * @param[in]   allow_insecure      Whether to allow insecure use.
  *
  * @return 0 success, 1 failed to find credential, 2 credential with new name
- *         exists, 3 credential_id required, 99 permission denied,
+ *         exists, 3 credential_id required, 4 invalid login name,
+ *         5 invalid certificate, 6 invalid auth_algorithm,
+ *         7 invalid privacy_algorithm, 8 invalid private key,
+ *         99 permission denied,
  *         -1 internal error.
  */
 int
@@ -41921,6 +41924,7 @@ modify_credential (const char *credential_id,
 {
   credential_t credential;
   iterator_t iterator;
+  int ret;
 
   if (credential_id == NULL)
     return 3;
@@ -41977,26 +41981,103 @@ modify_credential (const char *credential_id,
              credential);
     }
 
-  if (login)
-    set_credential_login (credential, login);
+  ret = 0;
 
-  if (certificate)
-    set_credential_certificate (credential, certificate);
+  if (login && ret == 0)
+    {
+      const char *s;
+      s = login;
+      // Check if login contains only alphanumeric characters
+      if (strcmp (login, "") == 0)
+        ret = 4;
+      while (*s && ret == 0)
+        if (isalnum (*s))
+          s++;
+        else
+          ret = 4;
 
-  if (auth_algorithm)
-    set_credential_auth_algorithm (credential, auth_algorithm);
+      if (ret == 0)
+        set_credential_login (credential, login);
+    }
 
-  if (privacy_algorithm)
-    set_credential_privacy_algorithm (credential, privacy_algorithm);
+  if (certificate && ret == 0)
+    {
+      // Truncate certificate which also validates it.
+      gchar *certificate_truncated;
+      certificate_truncated = truncate_certificate (certificate);
+      if (certificate_truncated == NULL)
+        {
+          set_credential_certificate (credential, certificate_truncated);
+          g_free (certificate_truncated);
+        }
+      else
+        ret = 5;
+    }
+
+  if (auth_algorithm && ret == 0)
+    {
+      if (strcmp (auth_algorithm, "md5")
+          && strcmp (auth_algorithm, "sha1"))
+        ret = 6;
+      else
+        set_credential_auth_algorithm (credential, auth_algorithm);
+    }
+
+  if (privacy_algorithm && ret == 0)
+    {
+      if (strcmp (auth_algorithm, "aes")
+          && strcmp (auth_algorithm, "des"))
+        ret = 7;
+      else
+        set_credential_privacy_algorithm (credential, privacy_algorithm);
+    }
+
+  if (ret)
+    {
+      sql_rollback ();
+      return ret;
+    }
 
   init_credential_iterator_one (&iterator, credential);
   if (next (&iterator))
     {
+      gchar *key_private_truncated = NULL;
       const char* type = credential_iterator_type (&iterator);
+
+      if (key_private)
+        {
+          if (key_private)
+            {
+              char *key_public;
+              /* Try truncate the private key, but if that fails try get the
+               * public key anyway, in case it's a key type that
+               * truncate_private_key does not understand. */
+              key_private_truncated = truncate_private_key (key_private);
+
+              key_public = openvas_ssh_public_from_private
+                              (key_private_truncated
+                                ? key_private_truncated
+                                : key_private,
+                               password
+                                ? password
+                                : credential_iterator_private_key (&iterator));
+
+              g_free (key_public);
+
+              if (key_public == NULL)
+                {
+                  sql_rollback ();
+                  cleanup_iterator (&iterator);
+                  return 8;
+                }
+            }
+        }
+
       if (strcmp (type, "cc") == 0)
         {
           if (key_private)
-            set_credential_private_key (credential, key_private, NULL);
+            set_credential_private_key (credential, key_private_truncated,
+                                        NULL);
         }
       else if (strcmp (type, "up") == 0)
         {
@@ -42009,8 +42090,8 @@ modify_credential (const char *credential_id,
             {
               set_credential_private_key
                 (credential,
-                 key_private
-                  ? key_private
+                 key_private_truncated
+                  ? key_private_truncated
                   : credential_iterator_private_key (&iterator),
                 password
                   ? password
@@ -42040,6 +42121,8 @@ modify_credential (const char *credential_id,
           sql_rollback ();
           cleanup_iterator (&iterator);
         }
+
+      g_free (key_private_truncated);
     }
   else
     {

--- a/src/omp.c
+++ b/src/omp.c
@@ -26369,8 +26369,40 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 4:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
-                                    "Attempt to change login or password of"
-                                    " packaged credential"));
+                                    "Login name must not be empty and contain"
+                                    " only alphanumeric characters"));
+                log_event_fail ("credential", "Credential",
+                                modify_credential_data->credential_id,
+                                "modified");
+                break;
+              case 5:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_credential",
+                                    "Invalid or empty certificate"));
+                log_event_fail ("credential", "Credential",
+                                modify_credential_data->credential_id,
+                                "modified");
+                break;
+              case 6:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_credential",
+                                    "Invalid or empty auth_algorithm"));
+                log_event_fail ("credential", "Credential",
+                                modify_credential_data->credential_id,
+                                "modified");
+                break;
+              case 7:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_credential",
+                                    "Invalid or empty privacy_algorithm"));
+                log_event_fail ("credential", "Credential",
+                                modify_credential_data->credential_id,
+                                "modified");
+                break;
+              case 8:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("modify_credential",
+                                    "Invalid or empty private key"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");


### PR DESCRIPTION
In the modify_credential function the parameters login, certificate,
 auth_algorithm, privacy_algorithm and key_private are now validated so
 the credential data are not overwritten with invalid values.