### PR TITLE
Check for resources in use when deleting users.

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -4058,6 +4058,11 @@ const char*
 tag_name_iterator_name (iterator_t*);
 
 int
+user_resources_in_use (user_t,
+                       const char *, int(*)(resource_t),
+                       const char *, int(*)(resource_t));
+
+int
 init_resource_tag_iterator (iterator_t*, const char*, resource_t, int,
                             const char*, int);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -64820,6 +64820,10 @@ manage_delete_user (GSList *log_config, const gchar *database,
       case 8:
         fprintf (stderr, "Invalid inheritor.\n");
         break;
+      case 9:
+        fprintf (stderr,
+                 "Resources owned by the user are still in use by others.\n");
+        break;
       default:
         fprintf (stderr, "Internal Error.\n");
         break;
@@ -65350,7 +65354,8 @@ copy_user (const char* name, const char* comment, const char *user_id,
  *
  * @return 0 success, 2 failed to find user, 4 user has active tasks,
  *         5 attempted suicide, 6 inheritor not found, 7 inheritor same as
- *         deleted user, 8 invalid inheritor, 99 permission denied, -1 error.
+ *         deleted user, 8 invalid inheritor, 9 resources still in use,
+ *         99 permission denied, -1 error.
  */
 int
 delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
@@ -65629,6 +65634,10 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
            inheritor, user);
       sql ("UPDATE users SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
+      sql ("UPDATE groups_trash SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
+      sql ("UPDATE roles_trash SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
 
       /* Delete user */
       sql ("DELETE FROM group_users WHERE \"user\" = %llu;", user);
@@ -65643,32 +65652,119 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
       return 0;
     }
 
-  /* Delete owned resources */
-
+  /* Delete settings and miscellaneous resources not referenced directly */
+  // Agents
+  /* skip the "in use" check because it always returns 0
+  if (user_resources_in_use (user,
+                             "agents", agent_in_use,
+                             "agents_trash", trash_agent_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  */
   sql ("DELETE FROM agents WHERE owner = %llu;", user);
   sql ("DELETE FROM agents_trash WHERE owner = %llu;", user);
+  // Settings
+  sql ("DELETE FROM settings WHERE owner = %llu;", user);
 
+  /* Delete data modifiers (not directly referenced) */
+  // Notes
+  sql ("DELETE FROM notes WHERE owner = %llu;", user);
+  sql ("DELETE FROM notes_trash WHERE owner = %llu;", user);
+  // Overrides
+  sql ("DELETE FROM overrides WHERE owner = %llu;", user);
+  sql ("DELETE FROM overrides_trash WHERE owner = %llu;", user);
+  // Tags
+  sql ("DELETE FROM tags WHERE owner = %llu;", user);
+  sql ("DELETE FROM tags_trash WHERE owner = %llu;", user);
+
+  /* Delete assets (not directly referenced) */
+  // Hosts
+  sql ("DELETE FROM host_details WHERE host IN"
+       " (SELECT id FROM hosts WHERE owner = %llu);", user);
+  sql ("DELETE FROM host_max_severities WHERE host IN"
+       " (SELECT id FROM hosts WHERE owner = %llu);", user);
+  sql ("DELETE FROM host_identifiers WHERE owner = %llu;", user);
+  sql ("DELETE FROM host_oss WHERE owner = %llu;", user);
+  sql ("DELETE FROM hosts WHERE owner = %llu;", user);
+  // OSs
+  sql ("DELETE FROM oss WHERE owner = %llu;", user);
+
+  /* Delete report data and tasks (not directly referenced) */
+  // Hosts
+  sql ("DELETE FROM report_counts WHERE \"user\" = %llu", user);
+  sql ("DELETE FROM report_host_details"
+       " WHERE report_host IN (SELECT id FROM report_hosts"
+       "                       WHERE report IN (SELECT id FROM reports"
+       "                                        WHERE owner = %llu));",
+       user);
+  sql ("DELETE FROM report_hosts"
+       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
+       user);
+  // Results
+  sql ("DELETE FROM results"
+       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
+       user);
+  // Reports
+  sql ("DELETE FROM reports WHERE owner = %llu;", user);
+
+  /* Delete tasks (not directly referenced) */
+  if (user_resources_in_use (user,
+                             "tasks", target_in_use,
+                             NULL, NULL))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM task_alerts"
+       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
+       user);
+  sql ("DELETE FROM task_files"
+       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
+       user);
+  sql ("DELETE FROM task_preferences"
+       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
+       user);
+  sql ("DELETE FROM tasks WHERE owner = %llu;", user);
+
+  /* Delete resouces directly used by tasks */
+  // Alerts
+  if (user_resources_in_use (user,
+                             "alerts", alert_in_use,
+                             "alerts_trash", trash_alert_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
   sql ("DELETE FROM alert_condition_data"
        " WHERE alert IN (SELECT id FROM alerts WHERE owner = %llu);",
        user);
-  sql ("DELETE FROM alert_condition_data"
+  sql ("DELETE FROM alert_condition_data_trash"
        " WHERE alert IN (SELECT id FROM alerts_trash WHERE owner = %llu);",
        user);
   sql ("DELETE FROM alert_event_data"
        " WHERE alert IN (SELECT id FROM alerts WHERE owner = %llu);",
        user);
-  sql ("DELETE FROM alert_event_data"
+  sql ("DELETE FROM alert_event_data_trash"
        " WHERE alert IN (SELECT id FROM alerts_trash WHERE owner = %llu);",
        user);
   sql ("DELETE FROM alert_method_data"
        " WHERE alert IN (SELECT id FROM alerts WHERE owner = %llu);",
        user);
-  sql ("DELETE FROM alert_method_data"
+  sql ("DELETE FROM alert_method_data_trash"
        " WHERE alert IN (SELECT id FROM alerts_trash WHERE owner = %llu);",
        user);
   sql ("DELETE FROM alerts WHERE owner = %llu;", user);
   sql ("DELETE FROM alerts_trash WHERE owner = %llu;", user);
-
+  // Configs
+  if (user_resources_in_use (user,
+                             "configs", config_in_use,
+                             "configs_trash", trash_config_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
   sql ("DELETE FROM nvt_selectors"
        " WHERE name IN (SELECT nvt_selector FROM configs WHERE owner = %llu)"
        " AND name != '" MANAGE_NVT_SELECTOR_UUID_ALL "'"
@@ -65684,60 +65780,60 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
        user);
   sql ("DELETE FROM configs WHERE owner = %llu;", user);
   sql ("DELETE FROM configs_trash WHERE owner = %llu;", user);
+  // Scanners
+  if (user_resources_in_use (user,
+                             "scanners", scanner_in_use,
+                             "scanners_trash", trash_scanner_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM scanners WHERE owner = %llu;", user);
+  sql ("DELETE FROM scanners_trash WHERE owner = %llu;", user);
+  // Schedules
+  if (user_resources_in_use (user,
+                             "schedules", schedule_in_use,
+                             "schedules_trash", trash_schedule_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM schedules WHERE owner = %llu;", user);
+  sql ("DELETE FROM schedules_trash WHERE owner = %llu;", user);
+  // Targets
+  if (user_resources_in_use (user,
+                             "targets", target_in_use,
+                             "targets_trash", trash_target_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM targets_login_data WHERE target IN"
+       " (SELECT id FROM targets WHERE owner = %llu);", user);
+  sql ("DELETE FROM targets_trash_login_data WHERE target IN"
+       " (SELECT id FROM targets_trash WHERE owner = %llu);", user);
+  sql ("DELETE FROM targets WHERE owner = %llu;", user);
+  sql ("DELETE FROM targets_trash WHERE owner = %llu;", user);
 
-  sql ("DELETE FROM credentials_data WHERE credential IN"
-       " (SELECT id FROM credentials WHERE owner = %llu);",
-       user);
-  sql ("DELETE FROM credentials_trash_data WHERE credential IN"
-       " (SELECT id FROM credentials_trash WHERE owner = %llu);",
-       user);
-
-  sql ("DELETE FROM credentials WHERE owner = %llu;", user);
-  sql ("DELETE FROM credentials_trash WHERE owner = %llu;", user);
-
-  sql ("DELETE FROM host_identifiers WHERE owner = %llu;", user);
-  sql ("DELETE FROM host_oss WHERE owner = %llu;", user);
-  sql ("DELETE FROM hosts WHERE owner = %llu;", user);
-
+  /* Delete resources used indirectly by tasks */
+  // Filters (used by alerts and settings)
+  if (user_resources_in_use (user,
+                             "filters", filter_in_use,
+                             "filters_trash", trash_filter_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
   sql ("DELETE FROM filters WHERE owner = %llu;", user);
   sql ("DELETE FROM filters_trash WHERE owner = %llu;", user);
-  sql ("DELETE FROM notes WHERE owner = %llu;", user);
-  sql ("DELETE FROM notes_trash WHERE owner = %llu;", user);
-
-  sql ("DELETE FROM oss WHERE owner = %llu;", user);
-
-  /* Make permissions global if they are owned by the user and are related
-   * to users/groups/roles that are owned by the user. */
-  sql ("UPDATE permissions SET owner = NULL"
-       " WHERE owner = %llu"
-       " AND ((subject_type = 'user' AND subject IN (SELECT id FROM users WHERE owner = %llu))"
-       "      OR (subject_type = 'group' AND subject IN (SELECT id FROM groups WHERE owner = %llu))"
-       "      OR (subject_type = 'role' AND subject IN (SELECT id FROM roles WHERE owner = %llu))"
-       "      OR (resource_type = 'user' AND resource IN (SELECT id FROM users WHERE owner = %llu))"
-       "      OR (resource_type = 'group' AND resource IN (SELECT id FROM groups WHERE owner = %llu))"
-       "      OR (resource_type = 'role' AND resource IN (SELECT id FROM roles WHERE owner = %llu)));",
-       user,
-       user,
-       user,
-       user,
-       user,
-       user,
-       user);
-
-  /* Make users, roles and groups global if they are owned by the user. */
-  sql ("UPDATE users SET owner = NULL WHERE owner = %llu;", user);
-  sql ("UPDATE roles SET owner = NULL WHERE owner = %llu;", user);
-  sql ("UPDATE groups SET owner = NULL WHERE owner = %llu;", user);
-
-  /* Remove all other permissions owned by the user or given on the user. */
-  sql ("DELETE FROM permissions"
-       " WHERE owner = %llu"
-       " OR subject_type = 'user' AND subject = %llu"
-       " OR (resource_type = 'user' AND resource = %llu);",  /* For Super. */
-       user,
-       user,
-       user);
-
+  // Port lists (used by targets)
+  if (user_resources_in_use (user,
+                             "port_lists", port_list_in_use,
+                             "port_lists_trash", trash_port_list_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
   sql ("DELETE FROM port_ranges"
        " WHERE port_list IN (SELECT id FROM port_lists WHERE owner = %llu);",
        user);
@@ -65747,7 +65843,16 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
        user);
   sql ("DELETE FROM port_lists WHERE owner = %llu;", user);
   sql ("DELETE FROM port_lists_trash WHERE owner = %llu;", user);
-
+  // Report formats (used by alerts)
+  if (user_resources_in_use (user,
+                             "report_formats",
+                             report_format_in_use,
+                             "report_formats_trash",
+                             trash_report_format_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
   sql ("DELETE FROM report_format_param_options"
        " WHERE report_format_param"
        "       IN (SELECT id FROM report_format_params"
@@ -65774,47 +65879,63 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
   sql ("DELETE FROM report_formats WHERE owner = %llu;", user);
   sql ("DELETE FROM report_formats_trash WHERE owner = %llu;", user);
 
-  sql ("DELETE FROM report_counts WHERE \"user\" = %llu", user);
-  sql ("DELETE FROM report_host_details"
-       " WHERE report_host IN (SELECT id FROM report_hosts"
-       "                       WHERE report IN (SELECT id FROM reports"
-       "                                        WHERE owner = %llu));",
+  /* Delete credentials last because they can be used in various places */
+  if (user_resources_in_use (user,
+                             "credentials", credential_in_use,
+                             "credentials_trash", trash_credential_in_use))
+    {
+      sql_rollback ();
+      return 9;
+    }
+  sql ("DELETE FROM credentials_data WHERE credential IN"
+       " (SELECT id FROM credentials WHERE owner = %llu);",
        user);
-  sql ("DELETE FROM report_hosts"
-       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
+  sql ("DELETE FROM credentials_trash_data WHERE credential IN"
+       " (SELECT id FROM credentials_trash WHERE owner = %llu);",
        user);
-  sql ("DELETE FROM results"
-       " WHERE report IN (SELECT id FROM reports WHERE owner = %llu);",
-       user);
-  sql ("DELETE FROM reports WHERE owner = %llu;", user);
 
-  sql ("DELETE FROM overrides WHERE owner = %llu;", user);
-  sql ("DELETE FROM overrides_trash WHERE owner = %llu;", user);
+  sql ("DELETE FROM credentials WHERE owner = %llu;", user);
+  sql ("DELETE FROM credentials_trash WHERE owner = %llu;", user);
+
+  /* Make permissions global if they are owned by the user and are related
+   * to users/groups/roles that are owned by the user. */
+  sql ("UPDATE permissions SET owner = NULL"
+       " WHERE owner = %llu"
+       " AND ((subject_type = 'user' AND subject IN (SELECT id FROM users WHERE owner = %llu))"
+       "      OR (subject_type = 'group' AND subject IN (SELECT id FROM groups WHERE owner = %llu))"
+       "      OR (subject_type = 'role' AND subject IN (SELECT id FROM roles WHERE owner = %llu))"
+       "      OR (resource_type = 'user' AND resource IN (SELECT id FROM users WHERE owner = %llu))"
+       "      OR (resource_type = 'group' AND resource IN (SELECT id FROM groups WHERE owner = %llu))"
+       "      OR (resource_type = 'role' AND resource IN (SELECT id FROM roles WHERE owner = %llu)));",
+       user,
+       user,
+       user,
+       user,
+       user,
+       user,
+       user);
+
+  /* Make users, roles and groups global if they are owned by the user. */
+  sql ("UPDATE users SET owner = NULL WHERE owner = %llu;", user);
+  sql ("UPDATE roles SET owner = NULL WHERE owner = %llu;", user);
+  sql ("UPDATE groups SET owner = NULL WHERE owner = %llu;", user);
+  sql ("UPDATE roles_trash SET owner = NULL WHERE owner = %llu;", user);
+  sql ("UPDATE groups_trash SET owner = NULL WHERE owner = %llu;", user);
+
+  /* Remove all other permissions owned by the user or given on the user. */
+  sql ("DELETE FROM permissions"
+       " WHERE owner = %llu"
+       " OR subject_type = 'user' AND subject = %llu"
+       " OR (resource_type = 'user' AND resource = %llu);",  /* For Super. */
+       user,
+       user,
+       user);
+
+  /* Delete permissions granted by the user */
   sql ("DELETE FROM permissions WHERE owner = %llu;", user);
   sql ("DELETE FROM permissions_trash WHERE owner = %llu;", user);
-  sql ("DELETE FROM schedules WHERE owner = %llu;", user);
-  sql ("DELETE FROM schedules_trash WHERE owner = %llu;", user);
-  sql ("DELETE FROM settings WHERE owner = %llu;", user);
-  sql ("DELETE FROM tags WHERE owner = %llu;", user);
-  sql ("DELETE FROM tags_trash WHERE owner = %llu;", user);
-  sql ("DELETE FROM targets WHERE owner = %llu;", user);
-  sql ("DELETE FROM targets_trash WHERE owner = %llu;", user);
 
-  sql ("DELETE FROM task_files"
-       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
-       user);
-  sql ("DELETE FROM task_alerts"
-       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
-       user);
-  sql ("DELETE FROM task_preferences"
-       " WHERE task IN (SELECT id FROM tasks WHERE owner = %llu);",
-       user);
-  sql ("DELETE FROM tasks WHERE owner = %llu;", user);
-
-  sql ("UPDATE groups SET owner = 0 WHERE owner = %llu;", user);
-  sql ("UPDATE roles SET owner = 0 WHERE owner = %llu;", user);
-  sql ("UPDATE users SET owner = 0 WHERE owner = %llu;", user);
-
+  /* Remove user from groups and roles */
   sql ("DELETE FROM group_users WHERE \"user\" = %llu;", user);
   sql ("DELETE FROM group_users_trash WHERE \"user\" = %llu;", user);
   sql ("DELETE FROM role_users WHERE \"user\" = %llu;", user);
@@ -66640,6 +66761,47 @@ manage_get_ldap_info (int *enabled, gchar **host, gchar **authdn,
 
   *cacert = sql_string ("SELECT value FROM meta"
                         " WHERE name = 'ldap_cacert';");
+}
+
+/**
+ * @brief Check if a user still has resources that are in use.
+ *
+ * @param
+ */
+int
+user_resources_in_use (user_t user,
+                       const char *table, int(*in_use)(resource_t),
+                       const char *trash_table, int(*trash_in_use)(resource_t))
+{
+  iterator_t iter;
+  int has_resource_in_use = 0;
+
+  init_iterator (&iter, "SELECT id FROM %s WHERE owner = %llu",
+                 table, user);
+  while (next (&iter) && has_resource_in_use == 0)
+    {
+      resource_t resource = iterator_int64 (&iter, 0);
+      has_resource_in_use = in_use (resource);
+    }
+  cleanup_iterator (&iter);
+  if (has_resource_in_use)
+    return 1;
+
+  if (trash_table == NULL || trash_in_use == NULL)
+    return 0;
+
+  init_iterator (&iter, "SELECT id FROM %s WHERE owner = %llu",
+                 trash_table, user);
+  while (next (&iter) && has_resource_in_use == 0)
+    {
+      resource_t resource = iterator_int64 (&iter, 0);
+      has_resource_in_use = trash_in_use (resource);
+    }
+  cleanup_iterator (&iter);
+  if (has_resource_in_use)
+    return 2;
+
+  return 0;
 }
 
 /**

--- a/src/omp.c
+++ b/src/omp.c
@@ -20900,6 +20900,32 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("delete_user",
                                     "Attempt to delete current user"));
                 break;
+              case 6:
+                if (send_find_error_to_client ("delete_user", "inheriting user",
+                                               delete_user_data->inheritor_id,
+                                               omp_parser))
+                  {
+                    error_send_to_client (error);
+                    return;
+                  }
+                break;
+              case 7:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("delete_user",
+                                    "Inheritor is the same as the deleted"
+                                    " user."));
+                break;
+              case 8:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("delete_user",
+                                    "Invalid inheritor."));
+                break;
+              case 9:
+                SEND_TO_CLIENT_OR_FAIL
+                 (XML_ERROR_SYNTAX ("delete_user",
+                                    "Resources owned by the user are still"
+                                    " in use by others."));
+                break;
               case 99:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("delete_user",


### PR DESCRIPTION
(Backport of PR #33)

When deleting users, check if resources are still in use by other users
after deleting resources that could use them. In this case, deleting the
user will fail.
The order in which resources owned by the deleted users are deleted has
been changed to ensure the referencing ones are deleted before the
referenced ones.