### PR TITLE
Skip credentials on all errors in slave_setup

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2648,16 +2648,11 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
 
               if (ret)
                 {
-                  if (ret == -1)
-                    goto fail;
-                  else
-                    {
-                      g_warning ("Could not create slave SSH credential"
-                                 " (status %d)."
-                                 " Continuing without credential.",
-                                 ret);
-                      slave_ssh_credential_uuid = NULL;
-                    }
+                  g_warning ("Could not create slave SSH credential"
+                              " (status %d)."
+                              " Continuing without credential.",
+                              ret);
+                  slave_ssh_credential_uuid = NULL;
                 }
             }
         }
@@ -2699,16 +2694,11 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               g_free (password_copy);
               if (ret)
                 {
-                  if (ret == -1)
-                    goto fail_ssh_credential;
-                  else
-                    {
-                      g_warning ("Could not create slave SMB credential"
-                                 " (status %d)."
-                                 " Continuing without credential.",
-                                 ret);
-                      slave_smb_credential_uuid = NULL;
-                    }
+                  g_warning ("Could not create slave SMB credential"
+                              " (status %d)."
+                              " Continuing without credential.",
+                              ret);
+                  slave_smb_credential_uuid = NULL;
                 }
             }
         }
@@ -2750,16 +2740,11 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               g_free (password_copy);
               if (ret)
                 {
-                  if (ret == -1)
-                    goto fail_smb_credential;
-                  else
-                    {
-                      g_warning ("Could not create slave ESXi credential"
-                                 " (status %d)."
-                                 " Continuing without credential.",
-                                 ret);
-                      slave_esxi_credential_uuid = NULL;
-                    }
+                  g_warning ("Could not create slave ESXi credential"
+                              " (status %d)."
+                              " Continuing without credential.",
+                              ret);
+                  slave_esxi_credential_uuid = NULL;
                 }
             }
         }
@@ -2825,16 +2810,11 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               g_free (privacy_algorithm_copy);
               if (ret)
                 {
-                  if (ret == -1)
-                    goto fail_esxi_credential;
-                  else
-                    {
-                      g_warning ("Could not create slave SNMP credential"
-                                 " (status %d)."
-                                 " Continuing without credential",
-                                 ret);
-                      slave_snmp_credential_uuid = NULL;
-                    }
+                  g_warning ("Could not create slave SNMP credential"
+                              " (status %d)."
+                              " Continuing without credential.",
+                              ret);
+                  slave_snmp_credential_uuid = NULL;
                 }
             }
         }


### PR DESCRIPTION
The function omp_read_create_response used in the functions used to
create credentials returns -1 if there is no id in the response, which
effectively means it will only return the OMP status on success.
Because of this it makes no sense to expect an OMP status code from
the credential creation functions in slave_setup, so now credentials
be skipped on any error when trying to create them on the slave.