### PR TITLE
Clean up credential iterators later in slave_setup

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2625,7 +2625,6 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
 
               user_copy = g_strdup (user);
               password_copy = g_strdup (password);
-              cleanup_iterator (&credentials);
 
               opts = omp_create_lsc_credential_opts_defaults;
               opts.name = name;
@@ -2639,6 +2638,8 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               else
                 private_key_copy = NULL;
               opts.comment = "Slave SSH credential created by Master";
+
+              cleanup_iterator (&credentials);
 
               ret = omp_create_lsc_credential_ext (&connection->session, opts,
                                                    &slave_ssh_credential_uuid);
@@ -2678,7 +2679,6 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
 
               user_copy = g_strdup (user);
               password_copy = g_strdup (password);
-              cleanup_iterator (&credentials);
 
               opts = omp_create_lsc_credential_opts_defaults;
               smb_name = g_strdup_printf ("%ssmb", name);
@@ -2686,6 +2686,8 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               opts.login = user_copy;
               opts.passphrase = password_copy;
               opts.comment = "Slave SMB credential created by Master";
+
+              cleanup_iterator (&credentials);
 
               ret = omp_create_lsc_credential_ext (&connection->session, opts,
                                                    &slave_smb_credential_uuid);
@@ -2724,7 +2726,6 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
 
               user_copy = g_strdup (user);
               password_copy = g_strdup (password);
-              cleanup_iterator (&credentials);
 
               opts = omp_create_lsc_credential_opts_defaults;
               esxi_name = g_strdup_printf ("%sesxi", name);
@@ -2732,6 +2733,8 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               opts.login = user_copy;
               opts.passphrase = password_copy;
               opts.comment = "Slave ESXi credential created by Master";
+
+              cleanup_iterator (&credentials);
 
               ret = omp_create_lsc_credential_ext (&connection->session, opts,
                                                    &slave_esxi_credential_uuid);
@@ -2786,7 +2789,6 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               auth_algorithm_copy = g_strdup (auth_algorithm);
               privacy_password_copy = g_strdup (privacy_password);
               privacy_algorithm_copy = g_strdup (privacy_algorithm);
-              cleanup_iterator (&credentials);
 
               opts = omp_create_lsc_credential_opts_defaults;
               snmp_name = g_strdup_printf ("%ssnmp", name);
@@ -2798,6 +2800,8 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
               opts.privacy_password = privacy_password_copy;
               opts.privacy_algorithm = privacy_algorithm_copy;
               opts.comment = "Slave SNMP credential created by Master";
+
+              cleanup_iterator (&credentials);
 
               ret = omp_create_lsc_credential_ext (&connection->session, opts,
                                                    &slave_snmp_credential_uuid);


### PR DESCRIPTION
The credential iterators in slave_setup are now cleaned up after all the
credentials data has been copied to opts struct for creating a copy
of the credential on the slave.
Otherwise some credential data variables like private key could point to
data from an already cleaned up iterator with a released lsc_crypt_ctx,
causing garbage data to be copied.