### PR TITLE
Use python3 in TP alert.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -545,6 +545,9 @@ Prerequisites for SNMP alert:
 Prerequisites for SMB alert:
 * smbclient
 
+Prerequisites for Tipping Point alert:
+* python3-lxml
+
 Prerequisites for splitting large XML files (see tools/extra/README):
 * python
 

--- a/src/alert_methods/TippingPoint/report-convert.py
+++ b/src/alert_methods/TippingPoint/report-convert.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 #
-# OpenVAS
+# GVM
 # $Id$
 # Description: Escalator method script: TippingPoint SMS upload.
 #


### PR DESCRIPTION
* src/alert_methods/TippingPoint/report-convert.py: Use explicitly python3
  instead of system default python to prevent being used with python2.
  It works with v2 s well, but we migrate all of GVM to v3.

* INSTALL: Add the prerequisite for the TP alert.