### PR TITLE
Allow special characters in credential login names

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41410,6 +41410,31 @@ set_credential_data (credential_t credential,
 }
 
 /**
+ * @brief Test if a username is valid to use in a credential.
+ *
+ * Valid usernames may only contain alphanumeric characters and a few
+ *  special ones to avoid problems with installer package generation.
+ *
+ * @param[in]  username  The username string to test.
+ *
+ * @return Whether the username is valid.
+ */
+static int
+validate_credential_username (const gchar *username)
+{
+  const char *s;
+  s = username;
+  while (*s)
+    if (isalnum (*s)
+        || strchr ("-_\\@", *s))
+      s++;
+    else
+      return 0;
+
+  return 1;
+}
+
+/**
  * @brief Length of password generated in create_credential.
  */
 #define PASSWORD_LENGTH 10
@@ -41434,7 +41459,7 @@ set_credential_data (credential_t credential,
  * @param[in]  allow_insecure  Whether to allow insecure uses.
  * @param[out] credential      Created Credential.
  *
- * @return 0 success, 1 LSC credential exists already, 2 name contains space,
+ * @return 0 success, 1 LSC credential exists already, 2 invalid username,
  *         3 Failed to create public key from private key/password,
  *         4 Invalid credential type, 5 login username missing,
  *         6 password missing, 7 private key missing, 8 certificate missing,
@@ -41601,8 +41626,20 @@ create_credential (const char* name, const char* comment, const char* login,
 
   /* Add non-secret data */
   if (login)
-    set_credential_data (new_credential,
-                         "username", login);
+    {
+      /*
+       * Ensure the login does not contain characters that cause problems
+       *  with package generation.
+       */
+      if (validate_credential_username (login) == 0)
+        {
+          sql_rollback ();
+          return 2;
+        }
+
+      set_credential_data (new_credential,
+                           "username", login);
+    }
   if (certificate)
     {
       gchar *certificate_truncated;
@@ -41771,23 +41808,6 @@ create_credential (const char* name, const char* comment, const char* login,
   /*
    * Auto-generate credential
    */
-
-  /* Ensure the login is alphanumeric, to help the package generation. */
-
-  if (login)
-    {
-      const char *s;
-      s = login;
-      while (*s)
-        if (isalnum (*s))
-          s++;
-        else
-          {
-            g_free (quoted_name);
-            sql_rollback ();
-            return 2;
-          }
-    }
 
   /* Create the keys and packages. */
 
@@ -41993,16 +42013,13 @@ modify_credential (const char *credential_id,
 
   if (login && ret == 0)
     {
-      const char *s;
-      s = login;
-      // Check if login contains only alphanumeric characters
-      if (strcmp (login, "") == 0)
+      /*
+       * Ensure the login is not empty and does not contain characters that
+       *  cause problems with package generation.
+       */
+      if (strcmp (login, "") == 0
+          || validate_credential_username (login) == 0)
         ret = 4;
-      while (*s && ret == 0)
-        if (isalnum (*s))
-          s++;
-        else
-          ret = 4;
 
       if (ret == 0)
         set_credential_login (credential, login);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -41426,7 +41426,7 @@ validate_credential_username (const gchar *username)
   s = username;
   while (*s)
     if (isalnum (*s)
-        || strchr ("-_\\@", *s))
+        || strchr ("-_\\.@", *s))
       s++;
     else
       return 0;

--- a/src/omp.c
+++ b/src/omp.c
@@ -22422,8 +22422,8 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
-                                    " characters if autogenerating"
-                                    " credential"));
+                                    " characters or the following:"
+                                    " - _ \\ @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26395,8 +26395,9 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
               case 4:
                 SEND_TO_CLIENT_OR_FAIL
                  (XML_ERROR_SYNTAX ("modify_credential",
-                                    "Login name must not be empty and contain"
-                                    " only alphanumeric characters"));
+                                    "Login name must not be empty and may"
+                                    " contain only alphanumeric characters"
+                                    " or the following: - _ \\ @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");

--- a/src/omp.c
+++ b/src/omp.c
@@ -22423,7 +22423,7 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("create_credential",
                                     "Login may only contain alphanumeric"
                                     " characters or the following:"
-                                    " - _ \\ @"));
+                                    " - _ \\ . @"));
                 break;
               case 3:
                 SEND_TO_CLIENT_OR_FAIL
@@ -26397,7 +26397,7 @@ omp_xml_handle_end_element (/* unused */ GMarkupParseContext* context,
                  (XML_ERROR_SYNTAX ("modify_credential",
                                     "Login name must not be empty and may"
                                     " contain only alphanumeric characters"
-                                    " or the following: - _ \\ @"));
+                                    " or the following: - _ \\ . @"));
                 log_event_fail ("credential", "Credential",
                                 modify_credential_data->credential_id,
                                 "modified");


### PR DESCRIPTION
The login usernames can now also contain these characters: - _ \ @

A new function validate_credential_username has been added to ensure
the check is consistent and it is also done when creating new
credentials because packages can be generated not only for
auto-generated credentials.