### PR TITLE
Remove HOST_START and HOST_END from REPORT

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -2186,26 +2186,6 @@ update_end_times (entity_t report)
   entities = report->entities;
   while ((end = first_entity (entities)))
     {
-      if (strcmp (entity_name (end), "host_end") == 0)
-        {
-          entity_t host;
-          char *text;
-
-          /* Set the end time this way first, in case the slave is
-           * very old. */
-
-          host = entity_child (end, "host");
-          if (host == NULL)
-            return -1;
-
-          text = entity_text (end);
-          while (*text && isspace (*text)) text++;
-          if (*text != '\0')
-            set_scan_host_end_time (current_report,
-                                    entity_text (host),
-                                    entity_text (end));
-        }
-
       if (strcmp (entity_name (end), "host") == 0)
         {
           entity_t ip, time;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -27700,18 +27700,6 @@ print_report_prognostic_xml (FILE *out, const char *host, int first_result, int
           double h_severity;
 
           PRINT (out,
-                 "<host_start>"
-                 "<host>%s</host>%s"
-                 "</host_start>"
-                 "<host_end>"
-                 "<host>%s</host>%s"
-                 "</host_end>",
-                 buffer_host->ip,
-                 scan_start,
-                 buffer_host->ip,
-                 scan_end);
-
-          PRINT (out,
                  "<host>"
                  "<ip>%s</ip>"
                  "<start>%s</start>"
@@ -30159,21 +30147,6 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
               PRINT (out,
                      "</host>");
-
-              PRINT (out,
-                     "<host_start>"
-                     "<host>%s</host>%s"
-                     "</host_start>",
-                     host,
-                     host_iterator_start_time (&hosts));
-              PRINT (out,
-                     "<host_end>"
-                     "<host>%s</host>%s"
-                     "</host_end>",
-                     host,
-                     host_iterator_end_time (&hosts)
-                       ? host_iterator_end_time (&hosts)
-                       : "");
             }
           cleanup_iterator (&hosts);
         }
@@ -30264,22 +30237,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
           PRINT (out,
                  "</host>");
-
-          PRINT (out,
-                 "<host_start><host>%s</host>%s</host_start>",
-                 host_iterator_host (&hosts),
-                 host_iterator_start_time (&hosts));
         }
-      cleanup_iterator (&hosts);
-
-      init_report_host_iterator (&hosts, report, NULL, 0);
-      while (next (&hosts))
-        PRINT (out,
-               "<host_end><host>%s</host>%s</host_end>",
-               host_iterator_host (&hosts),
-               host_iterator_end_time (&hosts)
-                ? host_iterator_end_time (&hosts)
-                : "");
       cleanup_iterator (&hosts);
     }
 
@@ -52460,23 +52418,27 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
   hosts = (*report)->entities;
   while ((host_start = first_entity (hosts)))
     {
-      if (strcmp (entity_name (host_start), "host_start") == 0)
+      if (strcmp (entity_name (host_start), "host") == 0)
         {
-          entity_t host;
+          entity_t ip;
           char *uuid;
 
-          host = entity_child (host_start, "host");
-          if (host == NULL)
+          ip = entity_child (host_start, "ip");
+          if (ip == NULL)
+            goto rollback_fail;
+
+          start = entity_child (host_start, "start");
+          if (start == NULL)
             goto rollback_fail;
 
           uuid = report_uuid (current_report);
-          host_notice (entity_text (host), "ip", entity_text (host),
+          host_notice (entity_text (ip), "ip", entity_text (ip),
                        "Report Host", uuid, 1, 1);
           free (uuid);
 
           set_scan_host_start_time (current_report,
-                                    entity_text (host),
-                                    entity_text (host_start));
+                                    entity_text (ip),
+                                    entity_text (start));
         }
       hosts = next_entities (hosts);
     }

--- a/src/report_formats/CSV_Results/CSV_Results.xsl
+++ b/src/report_formats/CSV_Results/CSV_Results.xsl
@@ -351,14 +351,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 </xsl:text>
 </xsl:template>
 
-<!-- MATCH HOST_START -->
-<xsl:template match="host_start">
-</xsl:template>
-
-<!-- MATCH HOST_END -->
-<xsl:template match="host_end">
-</xsl:template>
-
 <!-- MATCH SCAN_START -->
 <xsl:template match="scan_start">
 </xsl:template>

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -1815,8 +1815,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <any><e>host</e></any>
             <e>timestamp</e>
             <e>scan_start</e>
-            <any><e>host_start</e></any>
-            <any><e>host_end</e></any>
             <e>scan_end</e>
             <e>errors</e>
           </g>
@@ -2872,30 +2870,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <name>scan_start</name>
         <summary>Start time of scan</summary>
         <pattern><t>iso_time</t></pattern>
-      </ele>
-      <ele>
-        <name>host_start</name>
-        <summary>Start time of a particular host</summary>
-        <pattern>
-          <t>iso_time</t>
-          <e>host</e>
-        </pattern>
-        <ele>
-          <name>host</name>
-          <pattern>text</pattern>
-        </ele>
-      </ele>
-      <ele>
-        <name>host_end</name>
-        <summary>End time of a particular host</summary>
-        <pattern>
-          <t>iso_time</t>
-          <e>host</e>
-        </pattern>
-        <ele>
-          <name>host</name>
-          <pattern>text</pattern>
-        </ele>
       </ele>
       <ele>
         <name>scan_end</name>
@@ -4908,8 +4882,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                 </result>
                 <truncated>...</truncated>
               </results>
-              <host_start>2010-02-02T19:11:21+00:00<host>127.0.1.1</host></host_start>
-              <host_end>2010-02-02T19:11:52+00:00<host>127.0.1.1</host></host_end>
               <scan_end>2010-02-02T19:11:52+00:00</scan_end>
               <errors>
                 <count>0</count>
@@ -13466,7 +13438,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <ele>
           <name>category</name>
           <summary>The category of the NVT</summary>
-	  <pattern><t>integer</t></pattern>
+      <pattern><t>integer</t></pattern>
         </ele>
         <ele>
           <name>creation_time</name>
@@ -16124,8 +16096,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                 </result>
                 <truncated>...</truncated>
               </results>
-              <host_start>2010-02-02T19:11:21+00:00<host>127.0.1.1</host></host_start>
-              <host_end>2010-02-02T19:11:52+00:00<host>127.0.1.1</host></host_end>
+              <host>
+                <ip>127.0.1.1</ip>
+                <asset asset_id="167a7f18-df86-4695-a6ff-2516ffe2ad43"/>
+                <start>2010-02-21T15:35:31Z</start>
+                <end>2010-02-21T16:31:13Z</end>
+                <truncated>...</truncated>
+              </host>
               <scan_end>2010-02-02T19:11:52+00:00</scan_end>
               <errors>
                 <count>0</count>
@@ -25649,6 +25626,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         The SYNC_FEED, SYNC_SCAP and SYNC_CERT commands have been removed, as
         they are no longer used by GSA, and they have been (or will be)
         superceded by automatic feed updating.
+      </p>
+    </description>
+    <version>8.0</version>
+  </change>
+  <change>
+    <command>GET_REPORTS</command>
+    <summary>HOST_START and HOST_END no longer returned</summary>
+    <description>
+      <p>
+        The element REPORT no longer contains the elements HOST_START and HOST_END.
+      </p>
+      <p>
+        Both elements were already redundant. The elements START and END of
+        the REPORT element HOST contain the same timestamps.
       </p>
     </description>
     <version>8.0</version>


### PR DESCRIPTION
Remove "host_start" and "host_end" XML elements from the report XML.
This information is part of the "host" element already as "start"
 and "end", so it is redundant.
