### PR TITLE
Add missing quote marks in report_severity.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -24984,7 +24984,7 @@ report_severity (report_t report, int overrides, int min_qod)
                  " FROM report_counts"
                  " WHERE report = %llu"
                  " AND override = %d"
-                 " AND user = (SELECT id FROM users WHERE uuid = '%s')"
+                 " AND \"user\" = (SELECT id FROM users WHERE uuid = '%s')"
                  " AND min_qod = %d"
                  " AND (end_time = 0 or end_time >= m_now ());",
                  report, overrides, current_credentials.uuid, min_qod);


### PR DESCRIPTION
In the report_severity function, add quote marks around "user" in the
iterator statement so PostgreSQL gets the correct table column, not the
current database user.