### PR TITLE
Fix loading greenbone-certdata-sync.conf

### DIFF
--- a/tools/greenbone-certdata-sync.in
+++ b/tools/greenbone-certdata-sync.in
@@ -79,7 +79,7 @@ LOCK_FILE=/tmp/gvm-sync-cert
 
 VERSION=@GVMD_VERSION@
 
-[ -r \"@GVM_SYSCONF_DIR@/greenbone-certdata-sync.conf\" ] && . \"@GVM_SYSCONF_DIR@/greenbone-certdata-sync.conf\"
+[ -r "@GVM_SYSCONF_DIR@/greenbone-certdata-sync.conf" ] && . "@GVM_SYSCONF_DIR@/greenbone-certdata-sync.conf"
 
 CERT_DIR="@GVM_CERT_DATA_DIR@"
 


### PR DESCRIPTION
The extra backslashes in greenbone-certdata-sync prevented it from loading additional configuration.