### PR TITLE
Fix find_resource_with_permission for SecInfo

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4463,7 +4463,7 @@ find_resource_with_permission (const char* type, const char* uuid,
   gchar *quoted_uuid;
   if (uuid == NULL)
     return TRUE;
-  if ((type == NULL) || (valid_type (type) == 0))
+  if ((type == NULL) || (valid_db_resource_type (type) == 0))
     return TRUE;
   quoted_uuid = sql_quote (uuid);
   if (acl_user_has_access_uuid (type, quoted_uuid, permission, trash) == 0)


### PR DESCRIPTION
The find_resource_with_permission function now checks the resource type
as used in DB table names, not the filter type.
This allows it to be used for SecInfo types like CVEs and NVTs, for
example when creating a tag.