### PR TITLE
Escape Task name in LaTeX and PDF report

### DIFF
--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -541,7 +541,9 @@ All dates are displayed using the timezone ``</xsl:text>
         <xsl:value-of select="timezone_abbrev"/>
         <xsl:text>''.
 The task was ``</xsl:text>
-        <xsl:value-of select="/report/task/name"/>
+        <xsl:call-template name="escape_text">
+          <xsl:with-param name="string" select="/report/task/name"/>
+        </xsl:call-template>
         <xsl:text>''.  The first scan started at </xsl:text>
         <xsl:apply-templates select="scan_start"/>
 <xsl:text> and ended at </xsl:text>
@@ -568,7 +570,9 @@ All dates are displayed using the timezone ``</xsl:text>
         <xsl:value-of select="timezone_abbrev"/>
         <xsl:text>''.
 The task was ``</xsl:text>
-        <xsl:value-of select="/report/task/name"/>
+        <xsl:call-template name="escape_text">
+          <xsl:with-param name="string" select="/report/task/name"/>
+        </xsl:call-template>
         <xsl:text>''.  The scan started at </xsl:text>
         <xsl:apply-templates select="scan_start"/>
 <xsl:text> and ended at </xsl:text>

--- a/src/report_formats/LaTeX/latex.xsl
+++ b/src/report_formats/LaTeX/latex.xsl
@@ -280,9 +280,9 @@ TODOS: Solve Whitespace/Indentation problem of this file.
       '%', '\%'),
       '&amp;','\&amp;'),
       '#', '\#'),
-      '^', '\^'),
       '}', '\}'),
-      '{', '\}')"/>
+      '{', '\}'),
+      '^', '\^{}')"/>
   </xsl:template>
 
   <!-- Escape text for normal latex environment. Following characters get a


### PR DESCRIPTION
To ensure task names with special characters do not cause problems in
the summary section of LaTeX and PDF reports, the escape_text template
is now applied to them.