### PR TITLE
Add tests for credential formats (master)

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -14624,6 +14624,7 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
   while (1)
     {
       const char *private_key, *login, *type, *cert;
+      gchar *formats_xml;
 
       ret = get_next (&credentials, &get_credentials_data->get,
                       &first, &count, init_credential_iterator);
@@ -14650,6 +14651,10 @@ handle_get_credentials (gmp_parser_t *gmp_parser, GError **error)
         login ? login : "",
         type ? type : "",
         type ? credential_full_type (type) : "");
+
+      formats_xml = credential_iterator_formats_xml (&credentials);
+      SEND_TO_CLIENT_OR_FAIL (formats_xml);
+      g_free (formats_xml);
 
       if (type && (strcmp (type, "snmp") == 0))
         {

--- a/src/manage.h
+++ b/src/manage.h
@@ -2119,6 +2119,20 @@ task_role_iterator_uuid (iterator_t*);
 
 /* Credentials. */
 
+/**
+ * @brief Export formats for credentials
+ */
+typedef enum
+{
+  CREDENTIAL_FORMAT_NONE = 0,   /// normal XML output
+  CREDENTIAL_FORMAT_KEY = 1,    /// public key
+  CREDENTIAL_FORMAT_RPM = 2,    /// RPM package
+  CREDENTIAL_FORMAT_DEB = 3,    /// DEB package
+  CREDENTIAL_FORMAT_EXE = 4,    /// EXE installer
+  CREDENTIAL_FORMAT_PEM = 5,    /// Certificate PEM
+  CREDENTIAL_FORMAT_ERROR = -1  /// Error / Invalid format
+} credential_format_t;
+
 gboolean
 find_credential_with_permission (const char*, credential_t*, const char*);
 

--- a/src/manage.h
+++ b/src/manage.h
@@ -2136,6 +2136,9 @@ typedef enum
 gboolean
 find_credential_with_permission (const char*, credential_t*, const char*);
 
+gboolean
+validate_credential_username_for_format (const gchar *, credential_format_t);
+
 int
 create_credential (const char*, const char*, const char*, const char*,
                    const char*, const char*, const char*, const char*,
@@ -2235,6 +2238,12 @@ credential_iterator_exe (iterator_t*);
 
 const char*
 credential_iterator_certificate (iterator_t*);
+
+gboolean
+credential_iterator_format_available (iterator_t*, credential_format_t);
+
+gchar *
+credential_iterator_formats_xml (iterator_t* iterator);
 
 char*
 credential_uuid (credential_t);

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -10331,6 +10331,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <alt>rpm</alt>
             <alt>deb</alt>
             <alt>exe</alt>
+            <alt>pem</alt>
           </alts>
         </type>
       </attrib>
@@ -10374,6 +10375,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>user_tags</e>
           <e>type</e>
           <e>full_type</e>
+          <e>formats</e>
           <o><e>auth_algorithm</e></o>
           <o><e>privacy</e></o>
           <o><e>certificate_info</e></o>
@@ -10382,6 +10384,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <or>
             <e>public_key</e>
             <e>package</e>
+            <e>certificate</e>
           </or>
         </pattern>
         <ele>
@@ -10524,6 +10527,28 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           </pattern>
         </ele>
         <ele>
+          <name>formats</name>
+          <summary>The export formats available for the credential</summary>
+          <pattern>
+            <any><e>format</e></any>
+          </pattern>
+          <ele>
+            <name>format</name>
+            <summary>Format as used in the command</summary>
+            <pattern>
+              <t>
+                <alts>
+                  <alt>key</alt>
+                  <alt>rpm</alt>
+                  <alt>deb</alt>
+                  <alt>exe</alt>
+                  <alt>pem</alt>
+                </alts>
+              </t>
+            </pattern>
+          </ele>
+        </ele>
+        <ele>
           <name>auth_algorithm</name>
           <summary>The SNMP authentication algorithm</summary>
           <pattern>
@@ -10638,6 +10663,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </attrib>
             base64
           </pattern>
+        </ele>
+        <ele>
+          <name>certificate</name>
+          <pattern>text</pattern>
         </ele>
       </ele>
       <ele>
@@ -10779,6 +10808,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </user_tags>
             <type>usk</type>
             <full_type>username + SSH key</full_type>
+            <formats>
+              <format>key</format>
+              <format>rpm</format>
+              <format>deb</format>
+            </formats>
           </credential>
           <credential id="8e305b0b-260d-450d-91a8-dadf0b144e15">
             <name>bob</name>
@@ -10790,6 +10824,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <login>bob</login>
             <type>up</type>
             <full_type>username + password</full_type>
+            <formats>
+              <format>exe</format>
+            </formats>
           </credential>
           <truncated>...</truncated>
         </get_credentials_response>


### PR DESCRIPTION
This adds tests which export formats can be used for a credential and new OMP elements to indicate the available formats.