### PR TITLE
Fix RPM package generation.

### DIFF
--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -297,7 +297,7 @@ lsc_user_rpm_create (const gchar *username,
 
   g_debug ("%s: Attempting RPM build\n", __FUNCTION__);
   cmd = (gchar **) g_malloc (5 * sizeof (gchar *));
-  cmd[0] = g_strdup ("./openvas-lsc-rpm-creator.sh");
+  cmd[0] = g_strdup ("./gvm-lsc-rpm-creator.sh");
   cmd[1] = g_strdup ("--target");
   cmd[2] = g_strdup (tmpdir);
   cmd[3] = g_build_filename (tmpdir, pubkey_basename, NULL);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -42035,7 +42035,7 @@ credential_iterator_rpm (iterator_t *iterator)
     }
   else if (lsc_user_rpm_recreate (login, public_key, &rpm, &rpm_size))
     {
-      g_warning ("%s: Failed to create RPM base for DEB\n", __FUNCTION__);
+      g_warning ("%s: Failed to create RPM\n", __FUNCTION__);
       g_free (public_key);
       return NULL;
     }


### PR DESCRIPTION
This fixes the path to the RPM generator script and the warning message
 in case the generation fails in the credential iterator.