### PR TITLE
Renamed external tool openvasmr to gvmcg.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -508,15 +508,15 @@ Prerequisites for generating credentials .exe packages:
 * makensis (usually distributed as part of nsis)
 
 Prerequisites for generating system reports:
-* A program in the PATH, with usage "gvmmr seconds type", where
+* A program in the PATH, with usage "gvmcg seconds type", where
   seconds is the number of seconds before now that the report covers,
   and type is the type of report.  When called with type "titles" the
   script must print a list of possible types, where the name of the
   type is everything up to the first space and everything else is a
-  title for the report.  When called with one of these types gvmmr
+  title for the report.  When called with one of these types gvmcg
   must print a PNG in base64 encoding.  When called with the special
-  type "blank", gvmmr must print a PNG in base64 for the Manager to
-  use when a request for one of the titled types fails.  gvmmr may
+  type "blank", gvmcg must print a PNG in base64 for the Manager to
+  use when a request for one of the titled types fails.  gvmcg may
   indicate failure by simply refraining from printing.
 
 Prerequisites for signature verification:

--- a/src/manage.c
+++ b/src/manage.c
@@ -5885,8 +5885,9 @@ get_slave_system_report_types (const char *required_type, gchar ***start,
 
 /**
  * @brief Command called by get_system_report_types.
+ *        gvmcg stands for gvm-create-graphs.
  */
-#define COMMAND "openvasmr 0 titles"
+#define COMMAND "gvmcg 0 titles"
 
 /**
  * @brief Get system report types.
@@ -5925,7 +5926,7 @@ get_system_report_types (const char *required_type, gchar ***start,
       || (WIFEXITED (exit_status) == 0)
       || WEXITSTATUS (exit_status))
     {
-      g_debug ("%s: openvasmr failed with %d", __FUNCTION__, exit_status);
+      g_debug ("%s: gvmcg failed with %d", __FUNCTION__, exit_status);
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
       g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
       g_free (astdout);
@@ -6249,21 +6250,21 @@ manage_system_report (const char *name, const char *duration,
     {
       if (end_time && strcmp (end_time, ""))
         {
-          command = g_strdup_printf ("openvasmr %ld %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      start_time_num,
                                      end_time_num,
                                      name);
         }
       else if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("openvasmr %ld %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      start_time_num,
                                      start_time_num + duration_num,
                                      name);
         }
       else
         {
-          command = g_strdup_printf ("openvasmr %ld %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      start_time_num,
                                      start_time_num + DEFAULT_DURATION,
                                      name);
@@ -6273,14 +6274,14 @@ manage_system_report (const char *name, const char *duration,
     {
       if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("openvasmr %ld %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      end_time_num - duration_num,
                                      end_time_num,
                                      name);
         }
       else
         {
-          command = g_strdup_printf ("openvasmr %ld %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %ld %s",
                                      end_time_num - DEFAULT_DURATION,
                                      end_time_num,
                                      name);
@@ -6290,13 +6291,13 @@ manage_system_report (const char *name, const char *duration,
     {
       if (duration && strcmp (duration, ""))
         {
-          command = g_strdup_printf ("openvasmr %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %s",
                                      duration_num,
                                      name);
         }
       else
         {
-          command = g_strdup_printf ("openvasmr %ld %s",
+          command = g_strdup_printf ("gvmcg %ld %s",
                                      DEFAULT_DURATION,
                                      name);
         }
@@ -6320,7 +6321,7 @@ manage_system_report (const char *name, const char *duration,
       gsize output_len;
       GString *buffer;
 
-      g_debug ("%s: openvasmr failed with %d", __FUNCTION__, exit_status);
+      g_debug ("%s: gvmcg failed with %d", __FUNCTION__, exit_status);
       g_debug ("%s: stdout: %s", __FUNCTION__, astdout);
       g_debug ("%s: stderr: %s", __FUNCTION__, astderr);
       g_free (astdout);


### PR DESCRIPTION
This is a follow up renaming towards gvm.
gvmcg stands for gvm create graphs.

The API of the tool remains unchanged. Just the
tool name needs to be renamed.

* src/manage.c (COMMAND, get_system_report_types, manage_system_report):
  Replace openvasmr by gvmcg.

* INSTALL: Rename gvmmr to gcmcg which is the actual new name.