### PR TITLE
 Add sql transactions with specific key

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53267,7 +53267,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   /* Get any new results and hosts from the slave. */
 
-  sql_begin_immediate ();
+  sql_begin_exclusive_lock (task);
   hosts = (*report)->entities;
   while ((host_start = first_entity (hosts)))
     {
@@ -53299,7 +53299,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   assert (current_report);
 
-  sql_begin_immediate ();
+  sql_begin_exclusive_lock (task);
   results = entity->entities;
   while ((entity = first_entity (results)))
     {

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -53267,7 +53267,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   /* Get any new results and hosts from the slave. */
 
-  sql_begin_exclusive_lock (task);
+  sql_begin_immediate_with_key (task);
   hosts = (*report)->entities;
   while ((host_start = first_entity (hosts)))
     {
@@ -53299,7 +53299,7 @@ update_from_slave (task_t task, entity_t get_report, entity_t *report,
 
   assert (current_report);
 
-  sql_begin_exclusive_lock (task);
+  sql_begin_immediate_with_key (task);
   results = entity->entities;
   while ((entity = first_entity (results)))
     {

--- a/src/sql.h
+++ b/src/sql.h
@@ -124,6 +124,12 @@ int
 sql_begin_exclusive_giveup ();
 
 void
+sql_begin_exclusive_lock (int);
+
+int
+sql_begin_exclusive_giveup_lock (int);
+
+void
 sql_begin_immediate ();
 
 int

--- a/src/sql.h
+++ b/src/sql.h
@@ -136,6 +136,12 @@ int
 sql_begin_immediate_giveup ();
 
 void
+sql_begin_immediate_with_key (int);
+
+int
+sql_begin_immediate_giveup_with_key (int);
+
+void
 sql_commit ();
 
 void

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -676,6 +676,30 @@ sql_begin_immediate_giveup ()
 }
 
 /**
+ * @brief Begin an immediate transaction.
+ *
+ * @param[in]  key       Transaction key may be a resource id.
+ */
+void
+sql_begin_immediate_with_key (int key)
+{
+  sql_begin_exclusive_lock (key);
+}
+
+/**
+ * @brief Begin an immediate transaction.
+ *
+ * @param[in]  key       A used transaction key.
+ *
+ * @return 0 got lock, 1 gave up, -1 error.
+ */
+int
+sql_begin_immediate_giveup_with_key (int key)
+{
+  return sql_begin_exclusive_giveup_lock (key);
+}
+
+/**
  * @brief Commit a transaction.
  */
 void

--- a/src/sql_pg.c
+++ b/src/sql_pg.c
@@ -621,6 +621,39 @@ sql_begin_exclusive_giveup ()
 }
 
 /**
+ * @brief Begin an exclusive transaction with a specific key.
+ *
+ * @param[in]  key       Transaction key may be a resource id.
+ */
+void
+sql_begin_exclusive_lock (int key)
+{
+    sql ("BEGIN;");
+    sql ("SELECT pg_advisory_xact_lock (%llu);", key);
+}
+
+/**
+ * @brief Begin an exclusive transaction, giving up on failure.
+ *
+ * @param[in]  key       A used transaction key.
+ *
+ * @return 0 got lock, 1 gave up, -1 error.
+ */
+int
+sql_begin_exclusive_giveup_lock (int key)
+{
+    int ret;
+
+    ret = sql_giveup ("BEGIN;");
+    if (ret)
+        return ret;
+    if (sql_int ("SELECT pg_try_advisory_xact_lock (%llu);", key))
+        return 0;
+    sql_rollback ();
+    return 1;
+}
+
+/**
  * @brief Begin an immediate transaction.
  */
 void

--- a/src/sql_sqlite3.c
+++ b/src/sql_sqlite3.c
@@ -542,6 +542,30 @@ sql_begin_exclusive_giveup ()
 }
 
 /**
+ * @brief Begin an exclusive transaction with a specific key.
+ *
+ * @param[in]  key       Transaction key may be a resource id.
+ */
+void
+sql_begin_exclusive_lock (int key)
+{
+  sql_begin_exclusive ();
+}
+
+/**
+ * @brief Begin an exclusive transaction, giving up on failure.
+ *
+ * @param[in]  key       A used transaction key.
+ *
+ * @return 0 got lock, 1 gave up, -1 error.
+ */
+int
+sql_begin_exclusive_giveup_lock (int key)
+{
+  return sql_begin_exclusive_giveup ();
+}
+
+/**
  * @brief Begin an exclusive transaction.
  */
 void
@@ -559,6 +583,30 @@ int
 sql_begin_immediate_giveup ()
 {
   return sql_giveup ("BEGIN IMMEDIATE;");
+}
+
+/**
+ * @brief Begin an immediate transaction.
+ *
+ * @param[in]  key       Transaction key may be a resource id.
+ */
+void
+sql_begin_immediate_with_key (int key)
+{
+  sql_begin_immediate;
+}
+
+/**
+ * @brief Begin an immediate transaction.
+ *
+ * @param[in]  key       A used transaction key.
+ *
+ * @return 0 got lock, 1 gave up, -1 error.
+ */
+int
+sql_begin_immediate_giveup_with_key (int key)
+{
+  return sql_begin_immediate_giveup ();
 }
 
 /**


### PR DESCRIPTION
Hi guys,

I've discovered a problem in GVM version 7.0.3

After adding transactions in update_from_slave there was a problem when multiple scans (2+) were running at the same time in slave scanners, because the transaction always used the same key (1)
The result was you could not run any omp command until the transaction was over, and the whole system seemed stuck.

```
$ omp --ping
OMP ping failed: Unknown error.

```

This PR solves the problem by passing different keys (the task ID) to each transaction.
