### PR TITLE
Limit size of result description / diff in OMP.

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -387,6 +387,103 @@ certificate_time_status (time_t activates, time_t expires)
 /* Helpers. */
 
 /**
+ * @brief Truncates text to a maximum length, optionally appends a suffix.
+ *
+ * Note: The string is modified in place instead of allocating a new one.
+ * With the xml option the function will avoid cutting the string in the middle
+ *  of XML entities, but element tags will be ignored.
+ *
+ * @param[in,out] string   The string to truncate.
+ * @param[in]     max_len  The maximum length in bytes.
+ * @param[in]     xml      Whether to preserve XML entities.
+ * @param[in]     suffix   The suffix to append when the string is shortened.
+ */
+void
+truncate_text (gchar *string, size_t max_len, gboolean xml, const char *suffix)
+{
+  if (strlen (string) <= max_len)
+    return;
+  else
+    {
+      size_t offset;
+      offset = max_len;
+
+      // Move offset according according to suffix length
+      if (suffix && strlen (suffix) < max_len)
+        offset = offset - strlen (suffix);
+
+      // Go back to start of UTF-8 character
+      if (offset > 0 && (string[offset] & 0x80) == 0x80)
+        {
+          offset = g_utf8_find_prev_char (string, string + offset) - string;
+        }
+
+      if (xml)
+        {
+          // If the offset is in the middle of an XML entity,
+          //  move the offset to the start of that entity.
+          ssize_t entity_start_offset = offset;
+
+          while (entity_start_offset >= 0 
+                 && string[entity_start_offset] != '&')
+            {
+              entity_start_offset --;
+            }
+
+          if (entity_start_offset >= 0)
+            {
+              char *entity_end = strchr(string + entity_start_offset, ';');
+              if (entity_end && (entity_end - string) >= offset)
+                offset = entity_start_offset;
+            }
+        }
+
+      // Truncate the string, inserting the suffix if applicable
+      if (suffix && strlen (suffix) < max_len)
+        sprintf (string + offset, "%s", suffix);
+      else
+        string[offset] = '\0';
+    }
+}
+
+/**
+ * @brief XML escapes text truncating to a maximum length with a suffix.
+ *
+ * Note: The function will avoid cutting the string in the middle of XML
+ *  entities.
+ *
+ * @param[in]  string   The string to truncate.
+ * @param[in]  max_len  The maximum length in bytes.
+ * @param[in]  suffix   The suffix to append when the string is shortened.
+ *
+ * @return Newly allocated string with XML escaped, truncated text.
+ */
+gchar *
+xml_escape_text_truncated (const char *string, size_t max_len,
+                           const char *suffix)
+{
+  gchar *escaped;
+  gssize orig_len;
+
+  orig_len = strlen (string);
+  if (orig_len <= max_len)
+    escaped = g_markup_escape_text (string, -1);
+  else
+    {
+      gchar *offset_next;
+      ssize_t offset;
+
+      offset_next = g_utf8_find_next_char (string + max_len,
+                                           string + orig_len);
+      offset = offset_next - string;
+      escaped = g_markup_escape_text (string, offset);
+    }
+
+  truncate_text (escaped, max_len, TRUE, suffix);
+  return escaped;
+}
+
+/**
  * @brief Free an slist of pointers, including the pointers.
  *
  * @param[in]  list  The list.

--- a/src/manage.h
+++ b/src/manage.h
@@ -4198,6 +4198,12 @@ manage_run_wizard (const gchar *, int (*) (void*, gchar*, gchar**),
 
 /* Helpers. */
 
+void
+truncate_text (gchar *, size_t, gboolean, const char *);
+
+gchar *
+xml_escape_text_truncated (const char *, size_t, const char *);
+
 char *
 iso_time (time_t *);
 

--- a/src/omp.c
+++ b/src/omp.c
@@ -11586,7 +11586,7 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
 {
   const char *descr = result_iterator_descr (results);
   const char *name, *owner_name, *comment, *creation_time, *modification_time;
-  gchar *nl_descr, *asset_id;
+  gchar *nl_descr, *nl_descr_escaped, *asset_id;
   const char *qod = result_iterator_qod (results);
   const char *qod_type = result_iterator_qod_type (results);
   result_t result = result_iterator_result (results);
@@ -11594,7 +11594,18 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
   char *detect_ref, *detect_cpe, *detect_loc, *detect_oid, *detect_name;
   task_t selected_task;
 
-  nl_descr = descr ? convert_to_newlines (descr) : NULL;
+  if (descr)
+    {
+      nl_descr = convert_to_newlines (descr);
+      nl_descr_escaped = xml_escape_text_truncated (nl_descr,
+                                                    TRUNCATE_TEXT_LENGTH,
+                                                    TRUNCATE_TEXT_SUFFIX);
+    }
+  else
+    {
+      nl_descr = NULL;
+      nl_descr_escaped = NULL;
+    }
 
   result_uuid (result, &uuid);
 
@@ -11740,14 +11751,16 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
     "<scan_nvt_version>%s</scan_nvt_version>"
     "<threat>%s</threat>"
     "<severity>%.1f</severity>"
-    "<qod><value>%s</value><type>%s</type></qod>"
-    "<description>%s</description>",
+    "<qod><value>%s</value><type>%s</type></qod>",
     result_iterator_scan_nvt_version (results),
     result_iterator_level (results),
     result_iterator_severity_double (results),
     qod ? qod : "",
-    qod_type ? qod_type : "",
-    descr ? nl_descr : "");
+    qod_type ? qod_type : "");
+
+  g_string_append_printf (buffer,
+                          "<description>%s</description>",
+                          descr ? nl_descr_escaped : "");
 
   if (include_overrides)
     buffer_xml_append_printf (buffer,
@@ -11792,9 +11805,13 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
               /* Remove the leading filename lines. */
               split = g_strsplit ((gchar*) diff, "\n", 3);
               if (split[0] && split[1] && split[2])
-                diff_xml = g_markup_escape_text (split[2], strlen (split[2]));
+                diff_xml = xml_escape_text_truncated (split[2],
+                                                      TRUNCATE_TEXT_LENGTH,
+                                                      TRUNCATE_TEXT_SUFFIX);
               else
-                diff_xml = g_markup_escape_text (diff, strlen (diff));
+                diff_xml = xml_escape_text_truncated (diff,
+                                                      TRUNCATE_TEXT_LENGTH,
+                                                      TRUNCATE_TEXT_SUFFIX);
               g_strfreev (split);
               g_string_append_printf (buffer, "<diff>%s</diff>", diff_xml);
               g_free (diff_xml);
@@ -11821,7 +11838,11 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
       g_string_append (buffer, "</delta>");
     }
 
-  if (descr) g_free (nl_descr);
+  if (descr)
+    {
+      g_free (nl_descr);
+      g_free (nl_descr_escaped);
+    }
 
   g_string_append (buffer, "</result>");
 }

--- a/src/omp.h
+++ b/src/omp.h
@@ -37,6 +37,16 @@
  */
 #define TO_CLIENT_BUFFER_SIZE 26214400
 
+/**
+ * @brief The maximum length in bytes for long result text like the description.
+ */
+#define TRUNCATE_TEXT_LENGTH 10000000
+
+/**
+ * @brief The text to append when text is truncated.
+ */
+#define TRUNCATE_TEXT_SUFFIX "[...]\n(text truncated)"
+
 int
 init_omp (GSList*, int, const gchar*, int, int, int, int, void (*) (),
           int (*) (openvas_connection_t *, gchar*),


### PR DESCRIPTION
Because libxml does not accept text nodes longer than 10000000 bytes by
default, limit result description and diff text to that size.