### PR TITLE
Update location of the Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_sqlite:
     docker:
-      - image: wiegandm/openvas-manager-7.0-sqlite-debian-jessie
+      - image: greenbone/build-env-gvm-openvas-manager-7.0-debian-jessie-gcc-sqlite
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -18,7 +18,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
   build_postgresql:
     docker:
-      - image: wiegandm/openvas-manager-7.0-postgresql-debian-jessie
+      - image: greenbone/build-env-gvm-openvas-manager-7.0-debian-jessie-gcc-postgresql
     steps:
       - run:
           working_directory: ~/gvm-libs


### PR DESCRIPTION
The name of the Docker images used for the CI steps has changed to
better reflect their purpose and to refer to the images stored in the
organizational account instead of an individual user account on Docker
hub.