### PR TITLE
Add option to enable support for coverage analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ if (NOT BACKEND STREQUAL POSTGRESQL)
   set (BACKEND SQLITE3)
 endif (NOT BACKEND STREQUAL POSTGRESQL)
 
+OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
+
 ## Retrieve git revision (at configure time)
 include (GetGit)
 
@@ -237,12 +239,16 @@ configure_file (tools/gvm-manage-certs.in tools/gvm-manage-certs @ONLY)
 
 ## Program
 
+if (ENABLE_COVERAGE)
+  set (COVERAGE_FLAGS "--coverage")
+endif (ENABLE_COVERAGE)
+
 set (HARDENING_FLAGS            "-Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector")
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 
 set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -Wall -D_BSD_SOURCE -D_ISOC99_SOURCE -D_SVID_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64")
 
-set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror")
+set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror ${COVERAGE_FLAGS}")
 set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS}")
 
 if (NOT SKIP_SRC)


### PR DESCRIPTION
This commit adds a new CMake option called `ENABLE_COVERAGE`. When
activated, this option will cause the `--coverage` option to passed to
the C compiler. This option is used to compile and link code
instrumented for coverage analysis.

Running code built with `--coverage` will result is coverage data and
notes being recorded and stored in the build directory. The recorded
data can then be consumed by `gcov` and related tools.

The `ENABLE_COVERAGE` option is only supported for the `Debug` build
type as compiler optimizations performed for other build types would
render the coverage measurements less meaningful.