### PR TITLE
Fix OS count and add "severity" filter column.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -61021,7 +61021,9 @@ asset_os_count (const get_data_t *get)
 {
   static const char *extra_columns[] = OS_ITERATOR_FILTER_COLUMNS;
   static column_t columns[] = OS_ITERATOR_COLUMNS;
-  return count ("os", get, columns, NULL, extra_columns, 0, 0, 0, TRUE);
+  static column_t where_columns[] = OS_ITERATOR_WHERE_COLUMNS;
+  return count2 ("os", get, columns, NULL, where_columns, NULL,
+                 extra_columns, 0, 0, 0, TRUE);
 }
 
 /**

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60837,7 +60837,8 @@ asset_host_count (const get_data_t *get)
  */
 #define OS_ITERATOR_FILTER_COLUMNS                                           \
  { GET_ITERATOR_FILTER_COLUMNS, "title", "hosts", "latest_severity",         \
-   "highest_severity", "average_severity", "average_severity_score", NULL }
+   "highest_severity", "average_severity", "average_severity_score",         \
+   "severity", NULL }
 
 /**
  * @brief OS iterator columns.
@@ -60914,6 +60915,18 @@ asset_host_count (const get_data_t *get)
      "       AS hosts)"                                                       \
      " AS severities)",                                                       \
      "average_severity_score",                                                \
+     KEYWORD_TYPE_DOUBLE                                                      \
+   },                                                                         \
+   {                                                                          \
+     "(SELECT round (CAST (avg (severity) AS numeric), 2)"                    \
+     " FROM (SELECT (SELECT severity FROM host_max_severities"                \
+     "               WHERE host = hosts.host"                                 \
+     "               ORDER BY creation_time DESC LIMIT 1)"                    \
+     "              AS severity"                                              \
+     "       FROM (SELECT distinct host FROM host_oss WHERE os = oss.id)"     \
+     "       AS hosts)"                                                       \
+     " AS severities)",                                                       \
+     "severity",                                                              \
      KEYWORD_TYPE_DOUBLE                                                      \
    },                                                                         \
    { NULL, NULL, KEYWORD_TYPE_UNKNOWN }                                       \


### PR DESCRIPTION
This adds "severity" as a copy of the "average_severity" column to OS assets and also fixes
an issue with the OS counting which would prevent using the new column.