### PR TITLE
Clean up iterator in the verify_scanner function

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48705,18 +48705,26 @@ verify_scanner (const char *scanner_id, char **version)
       host = scanner_iterator_host (&scanner);
       port = scanner_iterator_port (&scanner);
       if (host == NULL)
-        return -1;
+        {
+          cleanup_iterator (&scanner);
+          return -1;
+        }
 
       if (connection_open (&connection, host, port))
-        return 2;
+        {
+          cleanup_iterator (&scanner);
+          return 2;
+        }
 
       if (omp_ping_c (&connection, 0, version))
         {
           openvas_connection_close (&connection);
+          cleanup_iterator (&scanner);
           return 2;
         }
       g_debug ("%s: *version: %s", __FUNCTION__, *version);
       openvas_connection_close (&connection);
+      cleanup_iterator (&scanner);
       return 0;
     }
   else if (scanner_iterator_type (&scanner) == SCANNER_TYPE_OSP)
@@ -48766,6 +48774,7 @@ verify_scanner (const char *scanner_id, char **version)
     {
       if (version)
         *version = g_strdup ("OTP/2.0");
+      cleanup_iterator (&scanner);
       return 0;
     }
   assert (0);


### PR DESCRIPTION
The iterator and its SQL statement are no longer left open when
returning from the OMP and CVE scanner cases.