### PR TITLE
Revert "Allow to create filters for vulnerabilities"

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -4223,8 +4223,7 @@ valid_type (const char* type)
          || (strcasecmp (type, "tag") == 0)
          || (strcasecmp (type, "target") == 0)
          || (strcasecmp (type, "task") == 0)
-         || (strcasecmp (type, "user") == 0)
-         || (strcasecmp (type, "vuln") == 0);
+         || (strcasecmp (type, "user") == 0);
 }
 
 /**


### PR DESCRIPTION
This reverts commit 3d8ad82d6646ba0518369a176ab0ad4abf15c138.
The type "vuln" isn't available in OpenVAS-9 / Manager 7.0.