### PR TITLE
Fallback to empty filter in print_report_xml_start

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -29160,9 +29160,9 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
     }
   else
     {
-      term = NULL;
-      /* Set the filter parameters to defaults. */
-      manage_report_filter_controls (term ? term : get->filter,
+      term = g_strdup ("");
+      /* Set the filter parameters to defaults */
+      manage_report_filter_controls (term,
                                      &first_result, &max_results, &sort_field,
                                      &sort_order, &result_hosts_only,
                                      &min_qod, &levels, &delta_states,


### PR DESCRIPTION
If there is no filter in print_report_xml_start (not even an empty one),
use an empty string as a fallback for initializing the keyword values.