### PR TITLE
Add CI job for checking documentation coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,26 @@ jobs:
       - run:
           name: Configure and Compile
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release .. && make install
+  doc_coverage:
+    docker:
+      - image: greenbone/code-metrics-doxy-coverage-debian-stretch
+    steps:
+      - checkout
+      - run:
+          name: Generate documentation (XML)
+          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc-xml 2> ~/doxygen-stderr.txt
+      - run:
+          name: Establish coverage
+          command: ~/doxy-coverage/doxy-coverage.py ~/project/build/doc/generated/xml/ > ~/documentation-coverage.txt
+      - store_artifacts:
+          path: ~/doxygen-stderr.txt
+      - store_artifacts:
+          path: ~/documentation-coverage.txt
 workflows:
   version: 2
   build:
     jobs:
       - build_sqlite
       - build_postgresql
+      - doc_coverage
+


### PR DESCRIPTION
This commit adds a CI job which generates the source code documentation
with Doxygen as XML and then analyzes the documentation coverage with
doxy-coverage.

Errors reported during the Doxygen run and the coverage results
themselves are stored as build artifacts.