### PR TITLE
Reassign correct hosts when setting identifiers

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3367,9 +3367,9 @@ slave_setup (gvm_connection_t *connection, const char *name, task_t task,
           free_entity (get_tasks);
 
           /* Add results to assets. */
-          hosts_set_identifiers ();
           if (current_report)
             {
+              hosts_set_identifiers (current_report);
               hosts_set_max_severity (current_report, NULL, NULL);
               hosts_set_details (current_report);
             }

--- a/src/manage.h
+++ b/src/manage.h
@@ -1227,7 +1227,7 @@ int
 manage_report_host_detail (report_t, const char *, const char *);
 
 void
-hosts_set_identifiers ();
+hosts_set_identifiers (report_t);
 
 void
 hosts_set_max_severity (report_t, int*, int*);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60029,7 +60029,7 @@ hosts_set_identifiers ()
                  * HOST_START in otp.c refer to the new host. */
                 sql ("UPDATE host_identifiers SET host = %llu"
                      " WHERE source_id = '%s'"
-                     " AND name = 'ip'",
+                     " AND name = 'ip'"
                      " AND value = '%s';",
                      host_new,
                      quoted_source_id,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -59911,8 +59911,6 @@ hosts_set_identifiers ()
               host_new = 0;
             }
 
-          g_free (quoted_host_name);
-
           /* Add the host identifiers. */
 
           index = 0;
@@ -60027,13 +60025,15 @@ hosts_set_identifiers ()
                 }
 
               if (host_new)
-                /* Make sure all existing identifiers from this report refer to
-                 * this host.  Currently these will only be the Report Host
-                 * identifiers added for OTP HOST_START in otp.c. */
+                /* Make sure the Report Host identifiers added for OTP
+                 * HOST_START in otp.c refer to the new host. */
                 sql ("UPDATE host_identifiers SET host = %llu"
-                     " WHERE source_id = '%s';",
+                     " WHERE source_id = '%s'"
+                     " AND name = 'ip'",
+                     " AND value = '%s';",
                      host_new,
-                     quoted_source_id);
+                     quoted_source_id,
+                     quoted_host_name);
 
               g_free (quoted_source_type);
               g_free (quoted_source_id);
@@ -60043,6 +60043,8 @@ hosts_set_identifiers ()
 
               index++;
             }
+
+          g_free (quoted_host_name);
           host_index++;
         }
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -59798,9 +59798,11 @@ identifier_free (identifier_t *identifier)
  * At the end of a scan this revises the decision about which asset host to use
  * for each host that has identifiers.  The rules for this decision are described
  * in \ref asset_rules.  (The initial decision is made by \ref host_notice.)
+ *
+ * @param[in]  report  Report that the identifiers come from.
  */
 void
-hosts_set_identifiers ()
+hosts_set_identifiers (report_t report)
 {
   if (identifier_hosts)
     {
@@ -59903,6 +59905,18 @@ hosts_set_identifiers ()
                    quoted_host_name);
 
               host_new = host = sql_last_insert_id ();
+
+              /* Make sure the Report Host identifiers added for OTP HOST_START in
+               * otp.c refer to the new host. */
+
+              sql ("UPDATE host_identifiers SET host = %llu"
+                   " WHERE source_id = (SELECT uuid FROM reports"
+                   "                    WHERE id = %llu)"
+                   " AND name = 'ip'"
+                   " AND value = '%s';",
+                   host_new,
+                   report,
+                   quoted_host_name);
             }
           else
             {
@@ -60023,17 +60037,6 @@ hosts_set_identifiers ()
                          sql_last_insert_id (),
                          host);
                 }
-
-              if (host_new)
-                /* Make sure the Report Host identifiers added for OTP
-                 * HOST_START in otp.c refer to the new host. */
-                sql ("UPDATE host_identifiers SET host = %llu"
-                     " WHERE source_id = '%s'"
-                     " AND name = 'ip'"
-                     " AND value = '%s';",
-                     host_new,
-                     quoted_source_id,
-                     quoted_host_name);
 
               g_free (quoted_source_type);
               g_free (quoted_source_id);
@@ -61328,7 +61331,7 @@ create_asset_report (const char *report_id, const char *term)
       cleanup_iterator (&details);
     }
   cleanup_iterator (&hosts);
-  hosts_set_identifiers ();
+  hosts_set_identifiers (report);
   apply_overrides_string = filter_term_value (term, "apply_overrides");
   if (apply_overrides_string)
     apply_overrides = atoi (apply_overrides_string);

--- a/src/otp.c
+++ b/src/otp.c
@@ -1582,9 +1582,9 @@ process_otp_scanner_input ()
                       /* Stop transaction now, because delete_task_lock and
                        * set_scan_end_time_otp run transactions themselves. */
                       manage_transaction_stop (TRUE);
-                      hosts_set_identifiers ();
                       if (current_report)
                         {
+                          hosts_set_identifiers (current_report);
                           hosts_set_max_severity (current_report, NULL, NULL);
                           hosts_set_details (current_report);
                           set_scan_end_time_otp (current_report, field);


### PR DESCRIPTION
At the end of a scan, when the host identifiers lead to a new host being
required, only reassign the identifiers that pertain to the current
host, instead of reassigning all host identifiers.