### PR TITLE
Reassign correct hosts when setting identifiers

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -3313,9 +3313,9 @@ slave_setup (openvas_connection_t *connection, const char *name, task_t task,
           free_entity (get_tasks);
 
           /* Add results to assets. */
-          hosts_set_identifiers ();
           if (current_report)
             {
+              hosts_set_identifiers (current_report);
               hosts_set_max_severity (current_report, NULL, NULL);
               hosts_set_details (current_report);
             }

--- a/src/manage.h
+++ b/src/manage.h
@@ -1209,7 +1209,7 @@ int
 manage_report_host_detail (report_t, const char *, const char *);
 
 void
-hosts_set_identifiers ();
+hosts_set_identifiers (report_t);
 
 void
 hosts_set_max_severity (report_t, int*, int*);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60528,7 +60528,7 @@ hosts_set_identifiers ()
                  * HOST_START in otp.c refer to the new host. */
                 sql ("UPDATE host_identifiers SET host = %llu"
                      " WHERE source_id = '%s'"
-                     " AND name = 'ip'",
+                     " AND name = 'ip'"
                      " AND value = '%s';",
                      host_new,
                      quoted_source_id,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -60410,8 +60410,6 @@ hosts_set_identifiers ()
               host_new = 0;
             }
 
-          g_free (quoted_host_name);
-
           /* Add the host identifiers. */
 
           index = 0;
@@ -60526,13 +60524,15 @@ hosts_set_identifiers ()
                 }
 
               if (host_new)
-                /* Make sure all existing identifiers from this report refer to
-                 * this host.  Currently these will only be the Report Host
-                 * identifiers added for OTP HOST_START in otp.c. */
+                /* Make sure the Report Host identifiers added for OTP
+                 * HOST_START in otp.c refer to the new host. */
                 sql ("UPDATE host_identifiers SET host = %llu"
-                     " WHERE source_id = '%s';",
+                     " WHERE source_id = '%s'"
+                     " AND name = 'ip'",
+                     " AND value = '%s';",
                      host_new,
-                     quoted_source_id);
+                     quoted_source_id,
+                     quoted_host_name);
 
               g_free (quoted_source_type);
               g_free (quoted_source_id);
@@ -60542,6 +60542,8 @@ hosts_set_identifiers ()
 
               index++;
             }
+
+          g_free (quoted_host_name);
           host_index++;
         }
 

--- a/src/otp.c
+++ b/src/otp.c
@@ -1567,9 +1567,9 @@ process_otp_scanner_input (void (*progress) ())
                       /* Stop transaction now, because delete_task_lock and
                        * set_scan_end_time_otp run transactions themselves. */
                       manage_transaction_stop (TRUE);
-                      hosts_set_identifiers ();
                       if (current_report)
                         {
+                          hosts_set_identifiers (current_report);
                           hosts_set_max_severity (current_report, NULL, NULL);
                           hosts_set_details (current_report);
                           set_scan_end_time_otp (current_report, field);


### PR DESCRIPTION
At the end of a scan, when the host identifiers lead to a new host being
required, only reassign the identifiers that pertain to the current
host, instead of reassigning all host identifiers.