### PR TITLE
Amend schedule data returned by get_tasks.

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19871,36 +19871,59 @@ handle_get_tasks (gmp_parser_t *gmp_parser, GError **error)
             {
               time_t first_time, next_time;
               int period, period_months, duration;
+              gchar *icalendar, *timezone;
 
-              if (schedule_info (schedule, &first_time, &next_time, &period,
-                                 &period_months, &duration) == 0)
-                SENDF_TO_CLIENT_OR_FAIL ("<schedule id=\"%s\">"
-                                         "<name>%s</name>"
-                                         "<next_time>%s</next_time>"
-                                         "<trash>%d</trash>"
-                                         "<first_time>%s</first_time>"
-                                         "<period>%d</period>"
-                                         "<period_months>"
-                                         "%d"
-                                         "</period_months>"
-                                         "<duration>%d</duration>"
-                                         "</schedule>"
-                                         "<schedule_periods>"
-                                         "%d"
-                                         "</schedule_periods>",
-                                         task_schedule_uuid,
-                                         task_schedule_name,
-                                         next_time
-                                          ? iso_time (&next_time)
-                                          : "over",
-                                         schedule_in_trash,
-                                         first_time
-                                          ? iso_time (&first_time)
-                                          : "",
-                                         period,
-                                         period_months,
-                                         duration,
-                                         task_schedule_periods (index));
+              icalendar = timezone = NULL;
+
+              if (schedule_info (schedule, schedule_in_trash,
+                                 &first_time, &next_time, &period,
+                                 &period_months, &duration,
+                                 &icalendar, &timezone) == 0)
+                {
+                  gchar *first_time_str, *next_time_str;
+
+                  // Copy ISO time strings to avoid one overwriting the other
+                  first_time_str = g_strdup (first_time
+                                              ? iso_time (&first_time)
+                                              : "");
+                  next_time_str = g_strdup (next_time
+                                              ? iso_time (&next_time)
+                                              : "over");
+
+                  SENDF_TO_CLIENT_OR_FAIL ("<schedule id=\"%s\">"
+                                           "<name>%s</name>"
+                                           "<trash>%d</trash>"
+                                           "<first_time>%s</first_time>"
+                                           "<next_time>%s</next_time>"
+                                           "<icalendar>%s</icalendar>"
+                                           "<period>%d</period>"
+                                           "<period_months>"
+                                           "%d"
+                                           "</period_months>"
+                                           "<duration>%d</duration>"
+                                           "<timezone>%s</timezone>"
+                                           "</schedule>"
+                                           "<schedule_periods>"
+                                           "%d"
+                                           "</schedule_periods>",
+                                           task_schedule_uuid,
+                                           task_schedule_name,
+                                           schedule_in_trash,
+                                           first_time_str,
+                                           next_time_str,
+                                           icalendar ? icalendar : "",
+                                           period,
+                                           period_months,
+                                           duration,
+                                           timezone ? timezone : "",
+                                           task_schedule_periods (index));
+
+                  g_free (first_time_str);
+                  g_free (next_time_str);
+                }
+
+              g_free (icalendar);
+              g_free (timezone);
             }
           else
             {

--- a/src/manage.h
+++ b/src/manage.h
@@ -2909,7 +2909,8 @@ int
 schedule_period (schedule_t);
 
 int
-schedule_info (schedule_t, time_t *, time_t *, int *, int *, int *);
+schedule_info (schedule_t, int, time_t *, time_t *, int *, int *, int *,
+               gchar **, gchar **);
 
 int
 init_schedule_iterator (iterator_t*, const get_data_t *);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -48416,28 +48416,35 @@ schedule_duration (schedule_t schedule)
  * @brief Return info about a schedule.
  *
  * @param[in]  schedule    Schedule.
+ * @param[in]  trash       Whether to get schedule from trash.
  * @param[out] first_time  First time schedule ran.
  * @param[out] next_time   Next time schedule will run.
  * @param[out] period      Period.
  * @param[out] period_months  Period months.
  * @param[out] duration       Duration.
+ * @param[out] byday          byday string.
+ * @param[out] icalendar      iCalendar string.
+ * @param[out] timezone       timezone string.
  *
  * @return 0 success, -1 error.
  */
 int
-schedule_info (schedule_t schedule, time_t *first_time, time_t *next_time,
-               int *period, int *period_months, int *duration)
+schedule_info (schedule_t schedule, int trash,
+               time_t *first_time, time_t *next_time,
+               int *period, int *period_months, int *duration,
+               gchar **icalendar, gchar **timezone)
 {
   iterator_t schedules;
 
   init_iterator (&schedules,
                  "SELECT"
                  " first_time,"
-                 " next_time (first_time, period,"
-                 "            period_months, byday),"
-                 " period, period_months, duration"
-                 " FROM schedules"
+                 " next_time_ical (icalendar, timezone),"
+                 " period, period_months, duration,"
+                 " icalendar, timezone"
+                 " FROM schedules%s"
                  " WHERE id = %llu",
+                 trash ? "_trash" : "",
                  schedule);
   if (next (&schedules))
     {
@@ -48446,6 +48453,8 @@ schedule_info (schedule_t schedule, time_t *first_time, time_t *next_time,
       *period = iterator_int (&schedules, 2);
       *period_months = iterator_int (&schedules, 3);
       *duration = iterator_int (&schedules, 4);
+      *icalendar = g_strdup (iterator_string (&schedules, 5));
+      *timezone = g_strdup (iterator_string (&schedules, 6));
       cleanup_iterator (&schedules);
       return 0;
     }

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -20715,28 +20715,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <required>1</required>
             </attrib>
             <e>name</e>
-            <o><e>next_time</e></o>
-            <o><e>permissions</e></o>
             <e>trash</e>
             <o><e>first_time</e></o>
+            <o><e>next_time</e></o>
+            <o><e>icalendar</e></o>
             <o><e>period</e></o>
             <o><e>period_months</e></o>
             <o><e>duration</e></o>
+            <o><e>timezone</e></o>
           </pattern>
           <ele>
             <name>name</name>
             <summary>The name of the schedule</summary>
             <pattern><t>name</t></pattern>
-          </ele>
-          <ele>
-            <name>next_time</name>
-            <summary>The next date and time the schedule will be run in ISO format or "over".</summary>
-            <pattern><t>iso_time</t></pattern>
-          </ele>
-          <ele>
-          <name>permissions</name>
-          <summary>Permissions the user has on the schedule</summary>
-          <pattern></pattern>
           </ele>
           <ele>
             <name>trash</name>
@@ -20746,6 +20737,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <ele>
             <name>first_time</name>
             <summary>The first time was or will be run</summary>
+            <pattern><t>iso_time</t></pattern>
+          </ele>
+          <ele>
+            <name>next_time</name>
+            <summary>The next date and time the schedule will be run in ISO format or "over".</summary>
+            <pattern><t>iso_time</t></pattern>
+          </ele>
+          <ele>
+            <name>icalendar</name>
+            <summary>iCalendar text containing the time data.</summary>
             <pattern><t>iso_time</t></pattern>
           </ele>
           <ele>
@@ -20762,6 +20763,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <name>duration</name>
             <summary>The maximum duration of the task in seconds or 0 for unlimited</summary>
             <pattern><t>integer</t></pattern>
+          </ele>
+          <ele>
+            <name>timezone</name>
+            <summary>The timezone the schedule will follow.</summary>
+            <pattern>text</pattern>
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
When listing the scheduled tasks with get_tasks, the schedule now
includes the iCalendar and timezone and the order of the elements is now
more like the order in get_schedules.
The first_time and next_time ISO strings are copied to avoid one
overwriting the other when sending schedule data in get_tasks.
The schedule_info function now also calculates the next due time using
iCalendar.