### PR TITLE
Allow empty duration when simplifiying an vevent

### DIFF
--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -964,7 +964,14 @@ icalendar_simplify_vevent (icalcomponent *vevent, GHashTable *used_tzids,
       icaltimetype dtend;
       dtend = icalcomponent_get_dtend (vevent);
 
-      duration = icaltime_subtract (dtend, dtstart);
+      if (icaltime_is_null_time (dtend))
+        {
+          duration = icaldurationtype_null_duration ();
+        }
+      else
+        {
+          duration = icaltime_subtract (dtend, dtstart);
+        }
     }
 
   /*


### PR DESCRIPTION
Don't always set a duration. Allow vevents without dtend and duration
properties. An event can have an open end.