### PR TITLE
Add delta reports to alerts

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1501,7 +1501,7 @@ int
 report_progress (report_t, task_t, gchar **);
 
 gchar *
-manage_report (report_t, const get_data_t *, report_format_t,
+manage_report (report_t, report_t, const get_data_t *, report_format_t,
                int, int, const char *,
                gsize *, gchar **, gchar **, gchar **, gchar **, gchar **);
 


### PR DESCRIPTION
Create a delta report instead of a full report according to method data
delta_type.  If delta_type is Previous then create a delta between the
current report and the most recently completed report.  If delta_type is
Report then create a delta between the current report and the report
given by UUID in method data delta_report_id.