### PR TITLE
Fix SQL in init_resource_tag_iterator

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66693,7 +66693,8 @@ init_resource_tag_iterator (iterator_t* iterator, const char* type,
                  "  (SELECT * FROM tag_resources"
                  "   WHERE resource_type = '%s'"
                  "   AND resource = %llu"
-                 "   AND resource_location = %d)"
+                 "   AND resource_location = %d"
+                 "   AND tag = tags.id)"
                  "%s"
                  " AND %s"
                  " ORDER BY %s %s;",


### PR DESCRIPTION
The inner SELECT now checks if the resource_type row belongs to the tag
of the outer SELECT.
Without this the iterator would return all tags if any tags for the
resource existed.