### PR TITLE
Info tag fix

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -7245,6 +7245,12 @@ gmp_xml_handle_start_element (/* unused */ GMarkupParseContext* context,
                                         : "",
                                        attribute_names,
                                        attribute_values);
+
+            // get_aggregates ignores pagination by default
+            if (find_attribute (attribute_names, attribute_values,
+                                "ignore_pagination", &attribute) == 0)
+              get_aggregates_data->get.ignore_pagination = 1;
+
             set_client_state (CLIENT_GET_AGGREGATES);
           }
         else if (strcasecmp ("GET_CONFIGS", element_name) == 0)

--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3121,7 +3121,7 @@ create_tables ()
        "                     'resource_type, resource, resource_location');");
   sql ("SELECT create_index ('tag_resources_by_resource_uuid',"
        "                     'tag_resources',"
-       "                     'resource_type, resource, resource_location');");
+       "                     'resource_type, resource_uuid');");
   sql ("SELECT create_index ('tag_resources_by_tag',"
        "                     'tag_resources', 'tag');");
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -65829,7 +65829,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
 
   switch (type_build_select (type,
                              "id, uuid",
-                             &resources_get, 0, 0, NULL, NULL, NULL,
+                             &resources_get, 0, 1, NULL, NULL, NULL,
                              &iterator_select))
     {
       case 0:
@@ -65933,7 +65933,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
 
   switch (type_build_select (type,
                              "id",
-                             &resources_get, 0, 0, NULL, NULL, NULL,
+                             &resources_get, 0, 1, NULL, NULL, NULL,
                              &iterator_select))
     {
       case 0:
@@ -67474,7 +67474,13 @@ type_build_select (const char *type, const char *columns_str,
     extra_where = type_extra_where (type, get->trash,
                                     filter ? filter : get->filter);
 
-  pagination_clauses = NULL;
+  if (get->ignore_pagination)
+    pagination_clauses = NULL;
+  else
+    pagination_clauses = g_strdup_printf (" OFFSET %d LIMIT %s",
+                                          first,
+                                          sql_select_limit (max));
+
 
   *select = g_strdup_printf
              ("SELECT%s %s"  // DISTINCT, columns
@@ -67504,6 +67510,7 @@ type_build_select (const char *type, const char *columns_str,
   g_free (opts_table);
   g_free (owned_clause);
   g_free (extra_where);
+  g_free (pagination_clauses);
 
   return 0;
 }

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -65686,9 +65686,8 @@ tag_add_resource (tag_t tag, const char *type, const char *uuid,
     already_added = sql_int ("SELECT count(*) FROM tag_resources"
                              " WHERE resource_type = '%s'"
                              " AND resource_uuid = %s"
-                             " AND resource_location = %d"
                              " AND tag = %llu",
-                             type, quoted_resource_uuid, location, tag);
+                             type, quoted_resource_uuid, tag);
   else
     already_added = sql_int ("SELECT count(*) FROM tag_resources"
                              " WHERE resource_type = '%s'"


### PR DESCRIPTION
This fixes the following issues with tag resources:
* The postgres creating the wrong index and not using it for SecInfo tags, which select the resource by UUID
* Pagination keywords not being applied for tagging by filter