### PR TITLE
Fix index tag_resources_by_resource_uuid

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3122,7 +3122,7 @@ create_tables ()
        "                     'resource_type, resource, resource_location');");
   sql ("SELECT create_index ('tag_resources_by_resource_uuid',"
        "                     'tag_resources',"
-       "                     'resource_type, resource, resource_location');");
+       "                     'resource_type, resource_uuid');");
   sql ("SELECT create_index ('tag_resources_by_tag',"
        "                     'tag_resources', 'tag');");
 


### PR DESCRIPTION
The index tag_resources_by_resource_uuid was created for the wrong
columns in the PostgreSQL version.