### PR TITLE
Limit resources shown by get_tags, update GMP doc

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -4178,7 +4178,7 @@ int
 tag_iterator_resources (iterator_t*);
 
 void
-init_tag_resources_iterator (iterator_t*, tag_t, int);
+init_tag_resources_iterator (iterator_t*, tag_t, int, int, int);
 
 resource_t
 tag_resource_iterator_id (iterator_t*);

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -15127,6 +15127,17 @@ check_db_settings ()
          "  'Auto Cache Rebuild',"
          "  'Whether to rebuild report caches on changes affecting severity.',"
          "  '1');");
+
+  if (sql_int ("SELECT count(*) FROM settings"
+               " WHERE uuid = '" SETTING_UUID_TAG_RESOURCES_PER_PAGE "'"
+               " AND " ACL_IS_GLOBAL () ";")
+      == 0)
+    sql ("INSERT into settings (uuid, owner, name, comment, value)"
+         " VALUES"
+         " ('" SETTING_UUID_TAG_RESOURCES_PER_PAGE "', NULL,"
+         "  'Tag Resources Per Page',"
+         "  'The default number of resources shown in the Tag details.',"
+         "  100);");
 }
 
 /**
@@ -62249,6 +62260,7 @@ modify_setting (const gchar *uuid, const gchar *name,
     }
 
   if (uuid && (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
+               || strcmp (uuid, SETTING_UUID_TAG_RESOURCES_PER_PAGE) == 0
                || strcmp (uuid, "f16bb236-a32d-4cd5-a880-e0fcf2599f59") == 0
                || strcmp (uuid, "6765549a-934e-11e3-b358-406186ea4fc5") == 0
                || strcmp (uuid, "77ec2444-e7f2-4a80-a59b-f4237782d93f") == 0
@@ -62284,10 +62296,11 @@ modify_setting (const gchar *uuid, const gchar *name,
           value_size = 0;
         }
 
-      if (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0)
+      if (strcmp (uuid, SETTING_UUID_ROWS_PER_PAGE) == 0
+          || strcmp (uuid, SETTING_UUID_TAG_RESOURCES_PER_PAGE) == 0)
         {
           const gchar *val;
-          /* Rows Per Page. */
+          /* Rows Per Page, Tag Resources Per Page. */
           val = value;
           while (*val && isdigit (*val)) val++;
           if (*val && strcmp (value, "-1"))
@@ -66665,21 +66678,27 @@ tag_iterator_resources (iterator_t* iterator)
  * @param[in]  iterator    Iterator.
  * @param[in]  tag         The tag to init the resources iterator for.
  * @param[in]  trash       Whether to get resources of tags in the trashcan.
+ * @param[in]  first       Index of first resource to show, starting at 1.
+ * @param[in]  rows        Maximum number of resources to show, -1 for all.
  *
  * @return 0 success, 1 failed to find tag, 2 failed to find filter,
  *         -1 error.
  */
 void
-init_tag_resources_iterator (iterator_t* iterator, tag_t tag, int trash)
+init_tag_resources_iterator (iterator_t* iterator, tag_t tag, int trash,
+                             int first, int rows)
 {
   init_iterator (iterator,
                  "SELECT resource, resource_uuid, resource_location,"
                  " resource_name (resource_type, resource_uuid,"
                  "                resource_location),"
                  " resource_type"
-                 " FROM tag_resources%s WHERE tag = %llu",
+                 " FROM tag_resources%s WHERE tag = %llu"
+                 " LIMIT %s OFFSET %d",
                  trash ? "_trash" : "",
-                 tag);
+                 tag,
+                 sql_select_limit (rows),
+                 first - 1);
 }
 
 /**

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -225,6 +225,12 @@
 #define SETTING_UUID_DEFAULT_CA_CERT "9ac801ea-39f8-11e6-bbaa-28d24461215b"
 
 /**
+ * @brief UUID of 'Tag Resources Per Page' setting.
+ */
+#define SETTING_UUID_TAG_RESOURCES_PER_PAGE \
+        "4e35770c-9a41-4d56-ab9a-a62a356fe597"
+
+/**
  * @brief Trust constant for error.
  */
 #define TRUST_ERROR 0

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -19102,6 +19102,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Whether to get only distinct tag names</summary>
         <type>boolean</type>
       </attrib>
+      <attrib>
+        <name>resources_first</name>
+        <summary>Index of the first resource to list, starting at 1</summary>
+        <type>integer</type>
+        <required>0</required>
+      </attrib>
+      <attrib>
+        <name>resources_rows</name>
+        <summary>Maximum number of resources to list</summary>
+        <type>integer</type>
+        <required>0</required>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -19213,7 +19225,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <name>resources</name>
           <summary>Identifies the resources the tag is to be attached to</summary>
           <pattern>
+            <attrib>
+              <name>first</name>
+              <summary>Index of the first resource listed, starting at 1</summary>
+              <type>integer</type>
+              <required>1</required>
+            </attrib>
+            <attrib>
+              <name>rows</name>
+              <summary>Maximum number of resources listed</summary>
+              <type>integer</type>
+              <required>1</required>
+            </attrib>
             <any><e>resource</e></any>
+            <e>count</e>
             <e>type</e>
           </pattern>
           <ele>
@@ -19243,6 +19268,28 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <name>permissions</name>
               <summary>Permissions the user has on the resource</summary>
               <pattern></pattern>
+            </ele>
+          </ele>
+          <ele>
+            <name>count</name>
+            <summary></summary>
+            <pattern>
+              <e>total</e>
+              <e>page</e>
+            </pattern>
+            <ele>
+              <name>total</name>
+              <summary>The total number of resources the tag is attached to</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
+            </ele>
+            <ele>
+              <name>page</name>
+              <summary>The number of resources currently shown for the tag</summary>
+              <pattern>
+                <t>integer</t>
+              </pattern>
             </ele>
           </ele>
           <ele>
@@ -19400,11 +19447,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Fri Apr 12 08:49:43 2013</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <resource id="b493b7a8-7489-11df-a3ec-002264764cea">
-              <type>target</type>
-              <name>Server 1</name>
-              <trash>0</trash>
-            </resource>
+            <resources first="1" rows="100">
+              <resource id="b493b7a8-7489-11df-a3ec-002264764cea">
+                <type>target</type>
+                <name>Server 1</name>
+                <trash>0</trash>
+              </resource>
+              <count>
+                <total>1</total>
+                <page>1</page>
+              </count>
+            </resources>
             <value>52.2788</value>
             <active>1</active>
             <orphaned>0</orphaned>


### PR DESCRIPTION
The number of resources shown in the details of a tag is now limited and
the resources_first and resources_rows attributes have been added to
control which and how many resources to list.
By default the number is 100, which can be controlled with the new
setting "Tag Resources Per Page".

The GMP documentation for get_tags has also been updated accordingly
and to consider some changes related to multiple resources per tag
previously not included.