### PR TITLE
Allow ranges and CIDR blocks in host_contains

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -523,6 +523,13 @@ manage_create_sql_functions ()
 
   sql ("SET role dba;");
 
+  sql ("CREATE OR REPLACE FUNCTION hosts_contains (text, text)"
+       " RETURNS boolean"
+       " AS '%s/libgvm-pg-server', 'sql_hosts_contains'"
+       " LANGUAGE C"
+       " IMMUTABLE;",
+       GVM_LIB_INSTALL_DIR);
+
   sql ("CREATE OR REPLACE FUNCTION max_hosts (text, text)"
        " RETURNS integer"
        " AS '%s/libgvm-pg-server', 'sql_max_hosts'"
@@ -1228,14 +1235,6 @@ manage_create_sql_functions ()
            "  SELECT null::text;"
            "$$ LANGUAGE SQL;");
     }
-
-  sql ("CREATE OR REPLACE FUNCTION hosts_contains (text, text)"
-       " RETURNS boolean AS $$"
-       /* Check if a host list contains a host. */
-       "  SELECT trim ($2)"
-       "         IN (SELECT trim (unnest (string_to_array ($1, ','))));"
-       "$$ LANGUAGE SQL"
-       " IMMUTABLE;");
 
   sql ("CREATE OR REPLACE FUNCTION make_uuid () RETURNS text AS $$"
        "  SELECT uuid_generate_v4 ()::text AS result;"

--- a/src/manage_pg_server.c
+++ b/src/manage_pg_server.c
@@ -52,6 +52,35 @@ textndup (text *text_arg, int length)
   return ret;
 }
 
+/**
+ * @brief Get the maximum number of hosts.
+ *
+ * @return The maximum number of hosts.
+ */
+static int
+get_max_hosts ()
+{
+  int ret;
+  int max_hosts = 4095;
+  SPI_connect ();
+  ret = SPI_exec ("SELECT coalesce ((SELECT value FROM meta"
+                  "                  WHERE name = 'max_hosts'),"
+                  "                 '4095');", /* Same as MANAGE_MAX_HOSTS. */
+                  1); /* Max 1 row returned. */
+  if (SPI_processed > 0 && ret > 0 && SPI_tuptable != NULL)
+    {
+      char *cell;
+
+      cell = SPI_getvalue (SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1);
+      elog (DEBUG1, "cell: %s", cell);
+      if (cell)
+        max_hosts = atoi (cell);
+    }
+  elog (DEBUG1, "done");
+  SPI_finish ();
+
+  return max_hosts;
+}
 
 PG_FUNCTION_INFO_V1 (sql_hosts_contains);
 
@@ -69,7 +98,7 @@ sql_hosts_contains (PG_FUNCTION_ARGS)
     {
       text *hosts_arg, *find_host_arg;
       char *hosts, *find_host;
-      int ret;
+      int max_hosts, ret;
 
       hosts_arg = PG_GETARG_TEXT_P(0);
       hosts = textndup (hosts_arg, VARSIZE (hosts_arg) - VARHDRSZ);
@@ -77,7 +106,10 @@ sql_hosts_contains (PG_FUNCTION_ARGS)
       find_host_arg = PG_GETARG_TEXT_P(1);
       find_host = textndup (find_host_arg, VARSIZE (find_host_arg) - VARHDRSZ);
 
-      if (gvm_hosts_str_contains ((gchar *) hosts, (gchar *) find_host))
+      max_hosts = get_max_hosts ();
+
+      if (hosts_str_contains ((gchar *) hosts, (gchar *) find_host,
+                              max_hosts))
         ret = 1;
       else
         ret = 0;
@@ -206,24 +238,7 @@ sql_max_hosts (PG_FUNCTION_ARGS)
           exclude = textndup (exclude_arg, VARSIZE (exclude_arg) - VARHDRSZ);
         }
 
-      max_hosts = 4095;
-      SPI_connect ();
-      ret = SPI_exec ("SELECT coalesce ((SELECT value FROM meta"
-                      "                  WHERE name = 'max_hosts'),"
-                      "                 '4095');", /* Same as MANAGE_MAX_HOSTS. */
-                      1); /* Max 1 row returned. */
-      if (SPI_processed > 0 && ret > 0 && SPI_tuptable != NULL)
-        {
-          char *cell;
-
-          cell = SPI_getvalue (SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1);
-          elog (INFO, "cell: %s", cell);
-          if (cell)
-            max_hosts = atoi (cell);
-        }
-      elog (INFO, "done");
-      SPI_finish ();
-
+      max_hosts = get_max_hosts ();
       ret = manage_count_hosts_max (hosts, exclude, max_hosts);
       pfree (hosts);
       pfree (exclude);

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -38,6 +38,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <gvm/base/hosts.h>
 #include <gvm/util/uuidutils.h>
 
 #undef G_LOG_DOMAIN
@@ -452,7 +453,6 @@ sql_make_uuid (sqlite3_context *context, int argc, sqlite3_value** argv)
 void
 sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
 {
-  gchar **split, **point, *stripped_host;
   const unsigned char *hosts, *host;
 
   assert (argc == 2);
@@ -471,24 +471,7 @@ sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
       return;
     }
 
-  stripped_host = g_strstrip (g_strdup ((gchar*) host));
-  split = g_strsplit ((gchar*) hosts, ",", 0);
-  point = split;
-  while (*point)
-    {
-      if (strcmp (g_strstrip (*point), stripped_host) == 0)
-        {
-          g_strfreev (split);
-          g_free (stripped_host);
-          sqlite3_result_int (context, 1);
-          return;
-        }
-      point++;
-    }
-  g_strfreev (split);
-  g_free (stripped_host);
-
-  sqlite3_result_int (context, 0);
+  sqlite3_result_int (context, gvm_hosts_str_contains (hosts, host));
 }
 
 /**

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -454,6 +454,7 @@ void
 sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
 {
   const unsigned char *hosts, *host;
+  int max_hosts;
 
   assert (argc == 2);
 
@@ -471,7 +472,11 @@ sql_hosts_contains (sqlite3_context *context, int argc, sqlite3_value** argv)
       return;
     }
 
-  sqlite3_result_int (context, gvm_hosts_str_contains (hosts, host));
+  max_hosts = sql_int ("SELECT coalesce ((SELECT value FROM meta"
+                       "                  WHERE name = 'max_hosts'),"
+                       "                 '4095');");
+
+  sqlite3_result_int (context, hosts_str_contains (hosts, host, max_hosts));
 }
 
 /**

--- a/src/manage_utils.c
+++ b/src/manage_utils.c
@@ -689,6 +689,39 @@ level_max_severity (const char *level, const char *class)
 }
 
 /**
+ * @brief Returns whether a host has an equal host in a hosts string.
+ * eg. 192.168.10.1 has an equal in a hosts string
+ * "192.168.10.1-5, 192.168.10.10-20" string while 192.168.10.7 doesn't.
+ *
+ * @param[in] host        The host object to find.
+ * @param[in] hosts_str   Hosts string to check.
+ * @param[in] max_hosts   Maximum number of hosts allowed in hosts_str.
+ *
+ * @return 1 if host has equal in hosts_str, 0 otherwise.
+ */
+int
+hosts_str_contains (const char* hosts_str, const char* find_host_str,
+                    int max_hosts)
+{
+  gvm_hosts_t *hosts, *find_hosts;
+
+  hosts = gvm_hosts_new_with_max (hosts_str, max_hosts);
+  find_hosts = gvm_hosts_new_with_max (find_host_str, 1);
+
+  if (hosts == NULL || find_hosts == NULL || find_hosts->count != 1)
+    {
+      gvm_hosts_free (hosts);
+      gvm_hosts_free (find_hosts);
+      return 0;
+    }
+
+  int ret = gvm_host_in_hosts (find_hosts->hosts->data, NULL, hosts);
+  gvm_hosts_free (hosts);
+  gvm_hosts_free (find_hosts);
+  return ret;
+}
+
+/**
  * @brief Check whether a resource type table name is valid.
  *
  * @param[in]  type  Type of resource.

--- a/src/manage_utils.h
+++ b/src/manage_utils.h
@@ -79,7 +79,11 @@ int
 valid_db_resource_type (const char*);
 
 
-typedef struct 
+int
+hosts_str_contains (const char*, const char*, int);
+
+
+typedef struct
 {
   icalcomponent *ical;
   icaltimezone *ical_tz;


### PR DESCRIPTION
Use the new gvm_hosts_str_contains function in the SQL function
host_contains to allow more ways to specify hosts like ranges
and CIDR blocks.
(Requires greenbone/gvm-libs#105)