### PR TITLE
Remove resources list from get_tags response

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -19359,44 +19359,16 @@ handle_get_tags (gmp_parser_t *gmp_parser, GError **error)
 
           SENDF_TO_CLIENT_OR_FAIL ("<resources>"
                                    "<type>%s</type>"
-                                   "<count><total>%d</total></count>",
-                                   tag_iterator_resource_type (&tags),
-                                   tag_iterator_resources (&tags));
-
-          if (get_tags_data->get.details)
-            {
-              iterator_t resources;
-
-              init_tag_resources_iterator (&resources,
-                                          get_iterator_resource (&tags),
-                                          get_tags_data->get.trash);
-
-              while (next (&resources))
-                {
-                  SENDF_TO_CLIENT_OR_FAIL
-                  ("<resource id=\"%s\">"
-                    "<name>%s</name>"
-                    "<trash>%d</trash>",
-                    tag_resource_iterator_uuid (&resources),
-                    tag_resource_iterator_name (&resources)
-                      ? tag_resource_iterator_name (&resources) : "",
-                    tag_resource_iterator_location (&resources));
-
-                  if (tag_resource_iterator_readable (&resources) == 0)
-                    SENDF_TO_CLIENT_OR_FAIL ("<permissions/>");
-
-                  SEND_TO_CLIENT_OR_FAIL ("</resource>");
-                }
-
-              cleanup_iterator (&resources);
-            }
-
-          SENDF_TO_CLIENT_OR_FAIL ("</resources>"
+                                   "<count><total>%d</total></count>"
+                                   "</resources>"
                                    "<value>%s</value>"
                                    "<active>%d</active>"
                                    "</tag>",
+                                   tag_iterator_resource_type (&tags),
+                                   tag_iterator_resources (&tags),
                                    value,
                                    tag_iterator_active (&tags));
+
           g_free (value);
         }
       count++;

--- a/src/manage.h
+++ b/src/manage.h
@@ -4177,9 +4177,6 @@ tag_iterator_value (iterator_t*);
 int
 tag_iterator_resources (iterator_t*);
 
-void
-init_tag_resources_iterator (iterator_t*, tag_t, int);
-
 resource_t
 tag_resource_iterator_id (iterator_t*);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66873,29 +66873,6 @@ tag_iterator_resources (iterator_t* iterator)
 }
 
 /**
- * @brief Initialise a tag resources iterator.
- *
- * @param[in]  iterator    Iterator.
- * @param[in]  tag         The tag to init the resources iterator for.
- * @param[in]  trash       Whether to get resources of tags in the trashcan.
- *
- * @return 0 success, 1 failed to find tag, 2 failed to find filter,
- *         -1 error.
- */
-void
-init_tag_resources_iterator (iterator_t* iterator, tag_t tag, int trash)
-{
-  init_iterator (iterator,
-                 "SELECT resource, resource_uuid, resource_location,"
-                 " resource_name (resource_type, resource_uuid,"
-                 "                resource_location),"
-                 " resource_type"
-                 " FROM tag_resources%s WHERE tag = %llu",
-                 trash ? "_trash" : "",
-                 tag);
-}
-
-/**
  * @brief Get the resource_location from a Tag iterator.
  *
  * @param[in]  iterator  Iterator.

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -25711,15 +25711,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <description>
       <p>
         In the tag commands the single RESOURCE element is replaced with a
-        RESOURCES element which contains the TYPE and which may contain
-        one or more RESOURCE elements to specify the resources the tag
-        is attached to.
+        RESOURCES element which contains the TYPE and which for CREATE_TAG
+        and MODIFY_TAG may contain one or more RESOURCE elements to specify
+        the resources the tag is to be attached to.
       </p>
       <p>
-        Additionally the filter keywords orphan, resource, resource_location,
-        resource_name and resource_uuid have been removed from GET_TAGS.
-        Instead the keyword resources has been added which selects the total
-        number of resources a tag is attached to.
+        To get the resources a tag is attached to, use a GET_... command of the
+        type given in the RESOURCES / TYPE element with the tag_id keyword
+        in the filter.
+      </p>
+      <p>
+        Additionally the tag filter keywords orphan, resource,
+        resource_location, resource_name and resource_uuid have been removed
+        from GET_TAGS. Instead the keyword resources has been added which
+        selects the total number of resources a tag is attached to.
       </p>
     </description>
     <version>8.0</version>


### PR DESCRIPTION
To get resources a tag is attached to, a get_... command should be used
which uses a tag_id keyword in the filter.