### PR TITLE
Ignore "Max Rows Per Page" for tag actions.

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66076,6 +66076,7 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
   resources_get.trash = LOCATION_TABLE;
   resources_get.type = g_strdup (type);
 
+  ignore_max_rows_per_page = 1;
   switch (type_build_select (type,
                              "id, uuid",
                              &resources_get, 0, 1, NULL, NULL, NULL,
@@ -66084,12 +66085,14 @@ tag_add_resources_filter (tag_t tag, const char *type, const char *filter)
       case 0:
         break;
       default:
+        ignore_max_rows_per_page = 0;
         g_warning ("%s: Failed to build filter SELECT", __FUNCTION__);
         sql_rollback ();
         g_free (resources_get.filter);
         g_free (resources_get.type);
         return -1;
     }
+  ignore_max_rows_per_page = 0;
 
   g_free (resources_get.filter);
   g_free (resources_get.type);
@@ -66208,6 +66211,7 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
   resources_get.trash = LOCATION_TABLE;
   resources_get.type = g_strdup (type);
 
+  ignore_max_rows_per_page = 1;
   switch (type_build_select (type,
                              "id",
                              &resources_get, 0, 1, NULL, NULL, NULL,
@@ -66216,12 +66220,14 @@ tag_remove_resources_filter (tag_t tag, const char *type, const char *filter)
       case 0:
         break;
       default:
+        ignore_max_rows_per_page = 0;
         g_warning ("%s: Failed to build filter SELECT", __FUNCTION__);
         sql_rollback ();
         g_free (resources_get.filter);
         g_free (resources_get.type);
         return -1;
     }
+  ignore_max_rows_per_page = 0;
 
   g_free (resources_get.filter);
   g_free (resources_get.type);


### PR DESCRIPTION
The setting no longer restricts the number of resources that can be
added or removed at once when creating or modifying a tag.