### PR TITLE
Check if verinice alerts use report formats

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -51338,7 +51338,8 @@ report_format_in_use (report_format_t report_format)
                     "      OR name = 'notice_report_format'"
                     "      OR name = 'scp_report_format'"
                     "      OR name = 'send_report_format'"
-                    "      OR name = 'smb_report_format');",
+                    "      OR name = 'smb_report_format'"
+                    "      OR name = 'verinice_server_report_format');",
                     report_format);
 }
 
@@ -51360,7 +51361,8 @@ trash_report_format_in_use (report_format_t report_format)
                     "      OR name = 'notice_report_format'"
                     "      OR name = 'scp_report_format'"
                     "      OR name = 'send_report_format'"
-                    "      OR name = 'smb_report_format');",
+                    "      OR name = 'smb_report_format'"
+                    "      OR name = 'verinice_server_report_format');",
                     report_format);
 }
 


### PR DESCRIPTION
The functions report_format_in_use and trash_report_format_in_use now
also check the alert method data for verinice_server_report_format.