### PR TITLE
Hide empty user_tags, notes, overrides elems

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -6027,6 +6027,7 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
   GString *buffer;
   const char *tag_type;
   iterator_t tags;
+  int tag_count;
 
   buffer = g_string_new ("");
 
@@ -6135,50 +6136,50 @@ send_get_common (const char *type, get_data_t *get, iterator_t *iterator,
     }
 
   tag_type = get->subtype ? get->subtype : get->type;
-
-  if (get->details || get->id)
-    {
-      buffer_xml_append_printf (buffer,
-                                "<user_tags>"
-                                "<count>%i</count>",
-                                resource_tag_count (tag_type,
-                                                    get_iterator_resource
-                                                      (iterator),
-                                                    1));
-
-      init_resource_tag_iterator (&tags, tag_type,
+  tag_count = resource_tag_count (tag_type,
                                   get_iterator_resource (iterator),
-                                  1, NULL, 1);
+                                  1);
 
-      while (next (&tags))
+  if (tag_count)
+    {
+      if (get->details || get->id)
         {
           buffer_xml_append_printf (buffer,
-                                    "<tag id=\"%s\">"
-                                    "<name>%s</name>"
-                                    "<value>%s</value>"
-                                    "<comment>%s</comment>"
-                                    "</tag>",
-                                    resource_tag_iterator_uuid (&tags),
-                                    resource_tag_iterator_name (&tags),
-                                    resource_tag_iterator_value (&tags),
-                                    resource_tag_iterator_comment (&tags));
+                                    "<user_tags>"
+                                    "<count>%i</count>",
+                                    tag_count);
+
+          init_resource_tag_iterator (&tags, tag_type,
+                                      get_iterator_resource (iterator),
+                                      1, NULL, 1);
+
+          while (next (&tags))
+            {
+              buffer_xml_append_printf (buffer,
+                                        "<tag id=\"%s\">"
+                                        "<name>%s</name>"
+                                        "<value>%s</value>"
+                                        "<comment>%s</comment>"
+                                        "</tag>",
+                                        resource_tag_iterator_uuid (&tags),
+                                        resource_tag_iterator_name (&tags),
+                                        resource_tag_iterator_value (&tags),
+                                        resource_tag_iterator_comment (&tags));
+            }
+
+          cleanup_iterator (&tags);
+
+          buffer_xml_append_printf (buffer,
+                                    "</user_tags>");
         }
-
-      cleanup_iterator (&tags);
-
-      buffer_xml_append_printf (buffer,
-                                "</user_tags>");
-    }
-  else
-    {
-      buffer_xml_append_printf (buffer,
-                                "<user_tags>"
-                                "<count>%i</count>"
-                                "</user_tags>",
-                                resource_tag_count (tag_type,
-                                                    get_iterator_resource
-                                                      (iterator),
-                                                    1));
+      else
+        {
+          buffer_xml_append_printf (buffer,
+                                    "<user_tags>"
+                                    "<count>%i</count>"
+                                    "</user_tags>",
+                                    tag_count);
+        }
     }
 
   if (send_to_client (buffer->str, write_to_client, write_to_client_data))
@@ -10680,7 +10681,12 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
 {
   while (next (notes))
     {
+      int tag_count;
       char *uuid_task, *uuid_result;
+
+      tag_count = resource_tag_count ("note",
+                                      get_iterator_resource (notes),
+                                      1);
 
       if (count)
         (*count)++;
@@ -10752,11 +10758,7 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
                                     "<in_use>0</in_use>"
                                     "<active>%i</active>"
                                     "<text excerpt=\"%i\">%s</text>"
-                                    "<orphan>%i</orphan>"
-                                    "<user_tags>"
-                                    "<count>%i</count>"
-                                    "</user_tags>"
-                                    "</note>",
+                                    "<orphan>%i</orphan>",
                                     get_iterator_owner_name (notes)
                                      ? get_iterator_owner_name (notes)
                                      : "",
@@ -10771,11 +10773,19 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
                                     ((note_iterator_task (notes)
                                       && (uuid_task == NULL))
                                      || (note_iterator_result (notes)
-                                         && (uuid_result == NULL))),
-                                    resource_tag_count ("note",
-                                                        get_iterator_resource
-                                                          (notes),
-                                                        1));
+                                         && (uuid_result == NULL))));
+
+          if (tag_count)
+            {
+              buffer_xml_append_printf (buffer,
+                                        "<user_tags>"
+                                        "<count>%i</count>"
+                                        "</user_tags>",
+                                        tag_count);
+            }
+
+          g_string_append (buffer, "</note>");
+
           g_free (excerpt);
         }
       else
@@ -10882,38 +10892,38 @@ buffer_notes_xml (GString *buffer, iterator_t *notes, int include_notes_details,
             buffer_xml_append_printf (buffer,
                                       "<result id=\"%s\"/>",
                                       uuid_result ? uuid_result : "");
-
-          buffer_xml_append_printf (buffer,
-                                    "<user_tags>"
-                                    "<count>%i</count>",
-                                    resource_tag_count ("note",
-                                                        get_iterator_resource
-                                                          (notes),
-                                                        1));
-
-          init_resource_tag_iterator (&tags, "note",
-                                      get_iterator_resource (notes),
-                                      1, NULL, 1);
-
-          while (next (&tags))
+          if (tag_count)
             {
               buffer_xml_append_printf (buffer,
-                                        "<tag id=\"%s\">"
-                                        "<name>%s</name>"
-                                        "<value>%s</value>"
-                                        "<comment>%s</comment>"
-                                        "</tag>",
-                                        resource_tag_iterator_uuid (&tags),
-                                        resource_tag_iterator_name (&tags),
-                                        resource_tag_iterator_value (&tags),
-                                        resource_tag_iterator_comment (&tags));
+                                        "<user_tags>"
+                                        "<count>%i</count>",
+                                        tag_count);
+
+              init_resource_tag_iterator (&tags, "note",
+                                          get_iterator_resource (notes),
+                                          1, NULL, 1);
+
+              while (next (&tags))
+                {
+                  buffer_xml_append_printf 
+                     (buffer,
+                      "<tag id=\"%s\">"
+                      "<name>%s</name>"
+                      "<value>%s</value>"
+                      "<comment>%s</comment>"
+                      "</tag>",
+                      resource_tag_iterator_uuid (&tags),
+                      resource_tag_iterator_name (&tags),
+                      resource_tag_iterator_value (&tags),
+                      resource_tag_iterator_comment (&tags));
+                }
+
+              cleanup_iterator (&tags);
+
+              g_string_append (buffer, "</user_tags>");
             }
 
-          cleanup_iterator (&tags);
-
-          buffer_xml_append_printf (buffer,
-                                    "</user_tags>"
-                                    "</note>");
+          g_string_append (buffer, "</note>");
         }
       free (uuid_task);
       free (uuid_result);
@@ -10936,7 +10946,11 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
 {
   while (next (overrides))
     {
+      int tag_count;
       char *uuid_task, *uuid_result;
+      tag_count = resource_tag_count ("override",
+                                      get_iterator_resource (overrides),
+                                      1);
 
       if (count)
         (*count)++;
@@ -11012,11 +11026,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                     "<severity>%s</severity>"
                                     "<new_threat>%s</new_threat>"
                                     "<new_severity>%s</new_severity>"
-                                    "<orphan>%i</orphan>"
-                                    "<user_tags>"
-                                    "<count>%i</count>"
-                                    "</user_tags>"
-                                    "</override>",
+                                    "<orphan>%i</orphan>",
                                     get_iterator_owner_name (overrides)
                                      ? get_iterator_owner_name (overrides)
                                      : "",
@@ -11039,11 +11049,19 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                     ((override_iterator_task (overrides)
                                       && (uuid_task == NULL))
                                      || (override_iterator_result (overrides)
-                                         && (uuid_result == NULL))),
-                                    resource_tag_count ("override",
-                                                        get_iterator_resource
-                                                          (overrides),
-                                                        1));
+                                         && (uuid_result == NULL))));
+
+          if (tag_count)
+            {
+              buffer_xml_append_printf (buffer,
+                                        "<user_tags>"
+                                        "<count>%i</count>"
+                                        "</user_tags>",
+                                        tag_count);
+            }
+
+          g_string_append (buffer, "</override>");
+
           g_free (excerpt);
         }
       else
@@ -11156,37 +11174,38 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                       "<result id=\"%s\"/>",
                                       uuid_result ? uuid_result : "");
 
-          buffer_xml_append_printf (buffer,
-                                    "<user_tags>"
-                                    "<count>%i</count>",
-                                    resource_tag_count ("override",
-                                                        get_iterator_resource
-                                                          (overrides),
-                                                        1));
-
-          init_resource_tag_iterator (&tags, "override",
-                                      get_iterator_resource (overrides),
-                                      1, NULL, 1);
-
-          while (next (&tags))
+          if (tag_count)
             {
               buffer_xml_append_printf (buffer,
-                                        "<tag id=\"%s\">"
-                                        "<name>%s</name>"
-                                        "<value>%s</value>"
-                                        "<comment>%s</comment>"
-                                        "</tag>",
-                                        resource_tag_iterator_uuid (&tags),
-                                        resource_tag_iterator_name (&tags),
-                                        resource_tag_iterator_value (&tags),
-                                        resource_tag_iterator_comment (&tags));
+                                        "<user_tags>"
+                                        "<count>%i</count>",
+                                        tag_count);
+
+              init_resource_tag_iterator (&tags, "note",
+                                          get_iterator_resource (overrides),
+                                          1, NULL, 1);
+
+              while (next (&tags))
+                {
+                  buffer_xml_append_printf 
+                     (buffer,
+                      "<tag id=\"%s\">"
+                      "<name>%s</name>"
+                      "<value>%s</value>"
+                      "<comment>%s</comment>"
+                      "</tag>",
+                      resource_tag_iterator_uuid (&tags),
+                      resource_tag_iterator_name (&tags),
+                      resource_tag_iterator_value (&tags),
+                      resource_tag_iterator_comment (&tags));
+                }
+
+              cleanup_iterator (&tags);
+
+              g_string_append (buffer, "</user_tags>");
             }
 
-          cleanup_iterator (&tags);
-
-          buffer_xml_append_printf (buffer,
-                                    "</user_tags>"
-                                    "</override>");
+          g_string_append (buffer, "</override>");
         }
       free (uuid_task);
       free (uuid_result);
@@ -11421,8 +11440,6 @@ static void
 buffer_result_notes_xml (GString *buffer, result_t result, task_t task,
                          int include_notes_details)
 {
-  g_string_append (buffer, "<notes>");
-
   if (task)
     {
       get_data_t get;
@@ -11430,20 +11447,26 @@ buffer_result_notes_xml (GString *buffer, result_t result, task_t task,
       memset (&get, '\0', sizeof (get));
       /* Most recent first. */
       get.filter = "sort-reverse=created owner=any permission=any";
+
+      if (note_count (&get, 0, result, task) == 0)
+        return;
+
       init_note_iterator (&notes,
                           &get,
                           0,
                           result,
                           task);
+
+      g_string_append (buffer, "<notes>");
       buffer_notes_xml (buffer,
                         &notes,
                         include_notes_details,
                         0,
                         NULL);
+      g_string_append (buffer, "</notes>");
+
       cleanup_iterator (&notes);
     }
-
-  g_string_append (buffer, "</notes>");
 }
 
 /**
@@ -11458,8 +11481,6 @@ static void
 buffer_result_overrides_xml (GString *buffer, result_t result, task_t task,
                              int include_overrides_details)
 {
-  g_string_append (buffer, "<overrides>");
-
   if (task)
     {
       get_data_t get;
@@ -11467,20 +11488,26 @@ buffer_result_overrides_xml (GString *buffer, result_t result, task_t task,
       memset (&get, '\0', sizeof (get));
       /* Most recent first. */
       get.filter = "sort-reverse=created owner=any permission=any";
+
+      if (override_count (&get, 0, result, task) == 0)
+        return;
+
       init_override_iterator (&overrides,
                               &get,
                               0,
                               result,
                               task);
+
+      g_string_append (buffer, "<overrides>");
       buffer_overrides_xml (buffer,
                             &overrides,
                             include_overrides_details,
                             0,
                             NULL);
+      g_string_append (buffer, "</overrides>");
+
       cleanup_iterator (&overrides);
     }
-
-  g_string_append (buffer, "</overrides>");
 }
 
 /**
@@ -11754,35 +11781,41 @@ buffer_results_xml (GString *buffer, iterator_t *results, task_t task,
 
   if (include_tags)
     {
-      buffer_xml_append_printf (buffer,
-                                "<user_tags>"
-                                "<count>%i</count>",
-                                resource_tag_count ("result", result, 1));
+      int tag_count = resource_tag_count ("result", result, 1);
 
-      if (include_tags_details)
+      if (tag_count)
         {
-          iterator_t tags;
+          buffer_xml_append_printf (buffer,
+                                    "<user_tags>"
+                                    "<count>%i</count>",
+                                    resource_tag_count ("result", result, 1));
 
-          init_resource_tag_iterator (&tags, "result", result, 1, NULL, 1);
-
-          while (next (&tags))
+          if (include_tags_details)
             {
-              buffer_xml_append_printf (buffer,
-                                        "<tag id=\"%s\">"
-                                        "<name>%s</name>"
-                                        "<value>%s</value>"
-                                        "<comment>%s</comment>"
-                                        "</tag>",
-                                        resource_tag_iterator_uuid (&tags),
-                                        resource_tag_iterator_name (&tags),
-                                        resource_tag_iterator_value (&tags),
-                                        resource_tag_iterator_comment (&tags));
+              iterator_t tags;
+
+              init_resource_tag_iterator (&tags, "result", result, 1, NULL, 1);
+
+              while (next (&tags))
+                {
+                  buffer_xml_append_printf 
+                     (buffer,
+                      "<tag id=\"%s\">"
+                      "<name>%s</name>"
+                      "<value>%s</value>"
+                      "<comment>%s</comment>"
+                      "</tag>",
+                      resource_tag_iterator_uuid (&tags),
+                      resource_tag_iterator_name (&tags),
+                      resource_tag_iterator_value (&tags),
+                      resource_tag_iterator_comment (&tags));
+                }
+
+              cleanup_iterator (&tags);
             }
 
-          cleanup_iterator (&tags);
+          buffer_xml_append_printf (buffer, "</user_tags>");
         }
-
-      buffer_xml_append_printf (buffer, "</user_tags>");
     }
 
   detect_ref = detect_cpe = detect_loc = detect_oid = detect_name = NULL;

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -29732,39 +29732,40 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (report)
     {
-      uuid = report_uuid (report);
+      int tag_count = resource_tag_count ("report", report, 1);
 
-      PRINT (out,
-            "<user_tags>"
-            "<count>%i</count>",
-            resource_tag_count ("report", report, 1));
-
-      if (get->details || get->id)
+      if (tag_count)
         {
-          iterator_t tags;
+          PRINT (out,
+                 "<user_tags>"
+                 "<count>%i</count>",
+                 tag_count);
 
-          init_resource_tag_iterator (&tags, "report", report, 1, NULL, 1);
-
-          while (next (&tags))
+          if (get->details || get->id)
             {
-              PRINT (out,
-                     "<tag id=\"%s\">"
-                     "<name>%s</name>"
-                     "<value>%s</value>"
-                     "<comment>%s</comment>"
-                     "</tag>",
-                     resource_tag_iterator_uuid (&tags),
-                     resource_tag_iterator_name (&tags),
-                     resource_tag_iterator_value (&tags),
-                     resource_tag_iterator_comment (&tags));
+              iterator_t tags;
+
+              init_resource_tag_iterator (&tags, "report", report, 1, NULL, 1);
+
+              while (next (&tags))
+                {
+                  PRINT (out,
+                        "<tag id=\"%s\">"
+                        "<name>%s</name>"
+                        "<value>%s</value>"
+                        "<comment>%s</comment>"
+                        "</tag>",
+                        resource_tag_iterator_uuid (&tags),
+                        resource_tag_iterator_name (&tags),
+                        resource_tag_iterator_value (&tags),
+                        resource_tag_iterator_comment (&tags));
+                }
+
+              cleanup_iterator (&tags);
             }
 
-          cleanup_iterator (&tags);
+          PRINT (out, "</user_tags>");
         }
-
-      PRINT (out, "</user_tags>");
-
-      free (uuid);
     }
 
   if (report)
@@ -29808,6 +29809,7 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       target_t target;
       gchar *progress_xml;
       iterator_t tags;
+      int task_tag_count = resource_tag_count ("task", task, 1);
 
       tsk_name = task_name (task);
 
@@ -29850,29 +29852,34 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
       free (tsk_name);
       free (tsk_uuid);
 
-      PRINT (out,
-             "<user_tags>"
-             "<count>%i</count>",
-             resource_tag_count ("task", task, 1));
-
-      init_resource_tag_iterator (&tags, "task", task, 1, NULL, 1);
-      while (next (&tags))
+      if (task_tag_count)
         {
           PRINT (out,
-                 "<tag id=\"%s\">"
-                 "<name>%s</name>"
-                 "<value>%s</value>"
-                 "<comment>%s</comment>"
-                 "</tag>",
-                 resource_tag_iterator_uuid (&tags),
-                 resource_tag_iterator_name (&tags),
-                 resource_tag_iterator_value (&tags),
-                 resource_tag_iterator_comment (&tags));
+                 "<user_tags>"
+                 "<count>%i</count>",
+                 task_tag_count);
+
+          init_resource_tag_iterator (&tags, "task", task, 1, NULL, 1);
+          while (next (&tags))
+            {
+              PRINT (out,
+                    "<tag id=\"%s\">"
+                    "<name>%s</name>"
+                    "<value>%s</value>"
+                    "<comment>%s</comment>"
+                    "</tag>",
+                    resource_tag_iterator_uuid (&tags),
+                    resource_tag_iterator_name (&tags),
+                    resource_tag_iterator_value (&tags),
+                    resource_tag_iterator_comment (&tags));
+            }
+          cleanup_iterator (&tags);
+
+          PRINT (out,
+                "</user_tags>");
         }
-      cleanup_iterator (&tags);
 
       PRINT (out,
-             "</user_tags>"
              "</task>");
 
       {

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -544,7 +544,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <e>in_use</e>
       <e>active</e>
       <e>orphan</e>
-      <e>user_tags</e>
+      <o><e>user_tags</e></o>
       <o>
         <g>
           <e>hosts</e>
@@ -881,7 +881,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <e>new_severity</e>
       <e>orphan</e>
       <e>permissions</e>
-      <e>user_tags</e>
+      <o><e>user_tags</e></o>
       <o>
         <g>
           <e>hosts</e>
@@ -1806,7 +1806,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <e>timezone</e>
             <e>timezone_abbrev</e>
             <e>permissions</e>
-            <e>user_tags</e>
+            <o><e>user_tags</e></o>
             <e>scan_run_status</e>
             <e>result_count</e>
             <e>severity</e>
@@ -2395,7 +2395,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>comment</e>
           <e>target</e>
           <e>progress</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
         </pattern>
         <ele>
           <name>name</name>
@@ -7303,7 +7303,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>in_use</e>
           <e>writable</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <or>
             <e>installer</e>
             <e>package</e>
@@ -7587,9 +7587,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-23T10:44:00+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <installer>
               <trust>
                 yes
@@ -7616,9 +7613,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-23T10:44:00+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <installer>
               <trust>
                 yes
@@ -7801,7 +7795,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>in_use</e>
           <e>writable</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>tasks</e>
           <o><e>families</e></o>
           <o><e>preferences</e></o>
@@ -8309,9 +8303,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </nvt_count>
             <in_use>1</in_use>
             <writable>0</writable>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
           </config>
           <truncated>...</truncated>
         </get_configs_response>
@@ -8337,9 +8328,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <growing>1</growing>
             </nvt_count>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <tasks>
               <task id="13bb418a-4220-4575-b35b-ec398bff7417">
                 <name>Web Servers</name>
@@ -9087,7 +9075,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>in_use</e>
           <e>writable</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>condition</e>
           <e>event</e>
           <e>method</e>
@@ -9487,9 +9475,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2012-08-28T12:14:00+01:00</modification_time>
             <writable>1</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <condition>
               Threat level at least
               <data>
@@ -9678,7 +9663,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <o><e>identifiers</e></o>
           <or>
             <e>host</e>
@@ -10198,9 +10183,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>0</writable>
             <in_use>7</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <hosts>localhost</hosts>
             <max_hosts>1</max_hosts>
             <ssh_credential id="">
@@ -10232,9 +10214,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>0</writable>
             <in_use>4</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <hosts>dik.example.org</hosts>
             <max_hosts>1</max_hosts>
             <ssh_credential id="58ff2793-2dc7-43fe-85f9-20bfac5a87e4">
@@ -10392,7 +10371,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>type</e>
           <e>full_type</e>
           <e>formats</e>
@@ -10823,9 +10802,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2012-05-28T11:19:20+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <type>usk</type>
             <full_type>username + SSH key</full_type>
             <formats>
@@ -10869,9 +10845,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2012-11-18T13:17:00+01:00</modification_time>
             <writable>1</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <login>bob</login>
             <type>up</type>
             <full_type>username + password</full_type>
@@ -10905,9 +10878,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2012-11-18T13:17:00+01:00</modification_time>
             <writable>1</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <type>up</type>
             <full_type>username + password</full_type>
             <targets>
@@ -11154,7 +11124,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>in_use</e>
           <e>writable</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <o><e>alerts</e></o>
         </pattern>
         <ele>
@@ -11440,9 +11410,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <type>target</type>
             <in_use>1</in_use>
             <writable>1</writable>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <creation_time>Sun Jun 27 08:49:46 2010</creation_time>
             <modification_time>Sun Jun 27 08:49:46 2010</modification_time>
           </filter>
@@ -11465,9 +11432,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <type></type>
             <in_use>1</in_use>
             <writable>1</writable>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <creation_time>Sun Jun 27 08:49:43 2010</creation_time>
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <alerts>
@@ -11575,7 +11539,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>users</e>
         </pattern>
         <ele>
@@ -11827,9 +11791,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <users>sarah, frank</users>
           </group>
           <truncated>...</truncated>
@@ -12194,7 +12155,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>creation_time</e>
           <e>modification_time</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>update_time</e>
           <or>
             <e>cert_bund_adv</e>
@@ -12860,9 +12821,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2007-09-14T17:36:49Z</modification_time>
             <writable>0</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <update_time>2012-10-26T13:18:00.000+0000</update_time>
             <cpe>
               <title>GNU Gzip 1.3.3</title>
@@ -12995,9 +12953,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <writable>0</writable>
             <in_use>0</in_use>
             <update_time>2012-10-26T13:18:00.000+0000</update_time>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <cve>
               <cvss>9.0</cvss>
               <vector>NETWORK</vector>
@@ -13301,9 +13256,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <in_use>0</in_use>
             <active>1</active>
             <orphan>1</orphan>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <text excerpt="0">This is the full text of the note.</text>
           </note>
           <truncated>...</truncated>
@@ -13336,9 +13288,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <name>test</name>
             </task>
             <orphan>0</orphan>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <result id="0c95e6b3-1100-4dfd-88f1-4bed1fad29de">
               <host>127.0.0.1</host>
               <port>general/tcp</port>
@@ -13466,7 +13415,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <required>1</required>
           </attrib>
           <e>name</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <o>
             <g>
               <e>creation_time</e>
@@ -13746,9 +13695,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <name>Services</name>
             <creation_time>2011-01-14T10:12:23+01:00</creation_time>
             <modification_time>2012-09-19T20:56:15+02:00</modification_time>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <category>3</category>
             <copyright>GNU GPL v2</copyright>
             <summary>Find what is listening on which port</summary>
@@ -13799,9 +13745,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <get_nvts_response status="200" status_text="OK">
           <nvt oid="1.3.6.1.4.1.25623.1.0.10330">
             <name>Services</name>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
           </nvt>
         </get_nvts_response>
       </response>
@@ -14175,9 +14118,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <new_threat>Log</new_threat>
             <new_severity>0.0</new_severity>
             <orphan>1</orphan>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
           </override>
           <truncated>...</truncated>
         </get_overrides_response>
@@ -14211,9 +14151,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <name>test</name>
             </task>
             <orphan>0</orphan>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <result id="0c95e6b3-1100-4dfd-88f1-4bed1fad29de" />
           </override>
           <truncated>...</truncated>
@@ -14346,7 +14283,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>resource</e>
           <e>subject</e>
         </pattern>
@@ -14671,9 +14608,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <users>sarah, frank</users>
           </permission>
           <truncated>...</truncated>
@@ -14826,7 +14760,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>port_count</e>
           <o><e>port_ranges</e></o>
           <o><e>targets</e></o>
@@ -15165,9 +15099,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2012-12-31T16:38:45+01:00</modification_time>
             <writable>0</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <port_count>
               <all>65535</all>
               <tcp>65535</tcp>
@@ -16063,9 +15994,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                   </keyword>
                 </keywords>
               </filters>
-              <user_tags>
-                <count>0</count>
-              </user_tags>
               <scan_run_status>Done</scan_run_status>
               <hosts>
                 <count>1</count>
@@ -16307,7 +16235,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>extension</e>
           <e>content_type</e>
           <e>summary</e>
@@ -16737,9 +16665,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-31T16:46:32+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <extension>html</extension>
             <content_type>text/html</content_type>
             <summary>Single page HTML report.</summary>
@@ -16774,9 +16699,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-18T18:24:10+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <extension>html</extension>
             <content_type>text/html</content_type>
             <summary>Single page HTML report.</summary>
@@ -17189,9 +17111,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <comment/>
             <creation_time>2014-05-23T09:22:12Z</creation_time>
             <modification_time>2014-05-23T09:22:12Z</modification_time>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <host>127.0.1.1</host>
             <port>general/tcp</port>
             <nvt oid="1.3.6.1.4.1.25623.1.0.74">
@@ -17250,9 +17169,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <comment/>
             <creation_time>2014-05-23T09:22:12Z</creation_time>
             <modification_time>2014-05-23T09:22:12Z</modification_time>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <host>127.0.0.1</host>
             <port>general/tcp</port>
             <nvt oid="1.3.6.1.4.1.25623.1.0.75">
@@ -17400,7 +17316,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>users</e>
         </pattern>
         <ele>
@@ -17652,9 +17568,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <users>sarah, frank</users>
           </role>
           <truncated>...</truncated>
@@ -17806,7 +17719,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>ca_pub_info</e>
           <e>certificate_info</e>
           <e>host</e>
@@ -18181,9 +18094,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2014-01-18T12:07:36+01:00</modification_time>
             <writable>0</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <host>localhost</host>
             <port>9391</port>
             <type>2</type>
@@ -18342,7 +18252,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>first_time</e>
           <e>next_time</e>
           <e>icalendar</e>
@@ -18694,9 +18604,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-18T12:07:36+01:00</modification_time>
             <writable>0</writable>
             <in_use>1</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <first_time>2010-07-29T00:00:00+02:00</first_time>
             <next_time>2010-07-29T00:00:00+02:00</next_time>
             <icalendar>[...]</icalendar>
@@ -19553,7 +19460,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>writable</e>
           <e>in_use</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>hosts</e>
           <e>exclude_hosts</e>
           <e>max_hosts</e>
@@ -20043,9 +19950,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>0</writable>
             <in_use>7</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <hosts>localhost</hosts>
             <max_hosts>1</max_hosts>
             <ssh_credential id="">
@@ -20077,9 +19981,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>Sun Jun 27 08:49:43 2010</modification_time>
             <writable>0</writable>
             <in_use>4</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <hosts>dik.example.org</hosts>
             <max_hosts>1</max_hosts>
             <ssh_credential id="58ff2793-2dc7-43fe-85f9-20bfac5a87e4">
@@ -20368,7 +20269,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <e>writable</e>
               <e>in_use</e>
               <e>permissions</e>
-              <e>user_tags</e>
+              <o><e>user_tags</e></o>
               <e>status</e>
               <e>progress</e>
               <e>alterable</e>
@@ -21267,9 +21168,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-11T16:03:24+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <owner>
               <name>admin</name>
             </owner>
@@ -21376,9 +21274,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <modification_time>2013-01-11T16:03:24+01:00</modification_time>
             <writable>1</writable>
             <in_use>0</in_use>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <owner>
               <name>admin</name>
             </owner>
@@ -21617,7 +21512,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <e>hosts</e>
           <e>ifaces</e>
           <e>permissions</e>
-          <e>user_tags</e>
+          <o><e>user_tags</e></o>
           <e>sources</e>
         </pattern>
         <ele>
@@ -21958,9 +21853,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <name>User</name>
             </role>
             <hosts allow="2"></hosts>
-            <user_tags>
-              <count>0</count>
-            </user_tags>
             <sources><source>file</source></sources>
           </user>
         </get_users_response>
@@ -25701,6 +25593,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         The OpenVAS Management Protocol (OMP) is renamed to Greenbone Management Protocol (GMP).
         The protocol as such does not change except for the changes documented here
         between OMP 7.0 and GMP 8.0.
+      </p>
+    </description>
+    <version>8.0</version>
+  </change>
+  <change>
+    <command>Most GET_... Commands</command>
+    <summary>USER_TAGS, NOTES, OVERRIDES hidden when empty</summary>
+    <description>
+      <p>
+        The USER_TAGS element in various GET_... commands and the NOTES and
+        OVERRIDES one in results is only included if there are tags etc.
+        for the result or other resource.
       </p>
     </description>
     <version>8.0</version>


### PR DESCRIPTION
To reduce the size of the XML responses, the user_tags, notes and
overrides element in various resources is now omitted if there are no
tags etc. for the current resource.