### PR TITLE
Add target name and comment to reports

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -1680,6 +1680,12 @@ target_name (target_t);
 char*
 trash_target_name (target_t);
 
+char*
+target_comment (target_t);
+
+char*
+trash_target_comment (target_t);
+
 int
 trash_target_readable (target_t);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -29805,7 +29805,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
   if (task && tsk_uuid)
     {
-      char *tsk_name, *task_target_uuid, *comment;
+      char *tsk_name, *task_target_uuid, *task_target_name;
+      char *task_target_comment, *comment;
       target_t target;
       gchar *progress_xml;
       iterator_t tags;
@@ -29817,9 +29818,17 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
 
       target = task_target (task);
       if (task_target_in_trash (task))
-        task_target_uuid = trash_target_uuid (target);
+        {
+          task_target_uuid = trash_target_uuid (target);
+          task_target_name = trash_target_name (target);
+          task_target_comment = trash_target_comment (target);
+        }
       else
-        task_target_uuid = target_uuid (target);
+        {
+          task_target_uuid = target_uuid (target);
+          task_target_name = target_name (target);
+          task_target_comment = target_comment (target);
+        }
 
       if ((target == 0)
           && (task_run_status (task) == TASK_STATUS_RUNNING))
@@ -29839,6 +29848,8 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
              "<comment>%s</comment>"
              "<target id=\"%s\">"
              "<trash>%i</trash>"
+             "<name>%s</name>"
+             "<comment>%s</comment>"
              "</target>"
              "<progress>%s</progress>",
              tsk_uuid,
@@ -29846,11 +29857,16 @@ print_report_xml_start (report_t report, report_t delta, task_t task,
              comment ? comment : "",
              task_target_uuid ? task_target_uuid : "",
              task_target_in_trash (task),
+             task_target_name ? task_target_name : "",
+             task_target_comment ? task_target_comment : "",
              progress_xml);
       g_free (progress_xml);
       free (comment);
       free (tsk_name);
       free (tsk_uuid);
+      free (task_target_uuid);
+      free (task_target_name);
+      free (task_target_comment);
 
       if (task_tag_count)
         {
@@ -35108,6 +35124,34 @@ char*
 trash_target_name (target_t target)
 {
   return sql_string ("SELECT name FROM targets_trash WHERE id = %llu;",
+                     target);
+}
+
+/**
+ * @brief Return the comment of a target.
+ *
+ * @param[in]  target  Target.
+ *
+ * @return Newly allocated name if available, else NULL.
+ */
+char*
+target_comment (target_t target)
+{
+  return sql_string ("SELECT comment FROM targets WHERE id = %llu;",
+                     target);
+}
+
+/**
+ * @brief Return the comment of a trashcan target.
+ *
+ * @param[in]  target  Target.
+ *
+ * @return Newly allocated name if available, else NULL.
+ */
+char*
+trash_target_comment (target_t target)
+{
+  return sql_string ("SELECT comment FROM targets_trash WHERE id = %llu;",
                      target);
 }
 

--- a/src/schema_formats/XML/GMP.xml.in
+++ b/src/schema_formats/XML/GMP.xml.in
@@ -2417,11 +2417,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <summary>The UUID of the target</summary>
             </attrib>
             <e>trash</e>
+            <e>name</e>
+            <e>comment</e>
           </pattern>
           <ele>
             <name>trash</name>
             <summary>Whether the target is in the trashcan</summary>
             <type>boolean</type>
+          </ele>
+          <ele>
+            <name>name</name>
+            <summary>The name of the target</summary>
+            <pattern><t>name</t></pattern>
+          </ele>
+          <ele>
+            <name>comment</name>
+            <summary>Comment for the target</summary>
+            <pattern>text</pattern>
           </ele>
         </ele>
         <ele>


### PR DESCRIPTION
The task target subelement of reports now contains the name and comment
of the target.