### PR TITLE
Change Debian LSC package maintainer 

### DIFF
--- a/src/lsc_user.h
+++ b/src/lsc_user.h
@@ -37,7 +37,8 @@ lsc_user_rpm_recreate (const gchar *, const gchar *,
                        void **, gsize *);
 
 int
-lsc_user_deb_recreate (const gchar *, const char *, void **, gsize *);
+lsc_user_deb_recreate (const gchar *, const char *, const char *,
+                       void **, gsize *);
 
 int
 lsc_user_exe_recreate (const gchar *, const gchar *, void **, gsize *);

--- a/src/manage.h
+++ b/src/manage.h
@@ -3924,6 +3924,9 @@ const char*
 setting_iterator_value (iterator_t*);
 
 int
+setting_value (const char *, char **);
+
+int
 setting_value_int (const char *, int *);
 
 int

--- a/src/manage_sql.h
+++ b/src/manage_sql.h
@@ -225,6 +225,11 @@
 #define SETTING_UUID_DEFAULT_CA_CERT "9ac801ea-39f8-11e6-bbaa-28d24461215b"
 
 /**
+ * @brief UUID of 'Debian LSC Package Maintainer' setting.
+ */
+#define SETTING_UUID_LSC_DEB_MAINTAINER "2fcbeac8-4237-438f-b52a-540a23e7af97"
+
+/**
  * @brief Trust constant for error.
  */
 #define TRUST_ERROR 0

--- a/tools/gvm-lsc-deb-creator.sh
+++ b/tools/gvm-lsc-deb-creator.sh
@@ -32,6 +32,7 @@ USERNAME="$1"
 PUBKEY_FILE="$2"
 TEMP_DIR="$3"
 OUTPUT_PATH=$4
+MAINTAINER_EMAIL="$5"
 
 if [ -z "${USERNAME}" ]
 then
@@ -57,12 +58,22 @@ then
   exit 1
 fi
 
+if [ -z "${MAINTAINER_EMAIL}" ]
+then
+  MAINTAINER_HOSTNAME="$(hostname)"
+  if [ -z "$HOSTNAME" ]
+  then
+    MAINTAINER_HOSTNAME="localhost"
+  fi
+  MAINTAINER_EMAIL="admin@${MAINTAINER_HOSTNAME}"
+fi
+
 # Constants
 # Package data
 PACKAGE_NAME="gvm-lsc-target-${USERNAME}"
 PACKAGE_VERSION="0.5-1"
 PACKAGE_NAME_VERSION="${PACKAGE_NAME}_${PACKAGE_VERSION}"
-MAINTAINER="Greenbone Vulnerability Manager  <info@openvas.org>"
+MAINTAINER="Greenbone Vulnerability Manager  <${MAINTAINER_EMAIL}>"
 PACKAGE_DATE=$(date "+%a, %d %b %Y %H:%M:%S %z")
 
 USER_COMMENT="GVM Local Security Checks"


### PR DESCRIPTION
This changes the maintainer email address of generated Debian LSC packages and adds a setting to override it with a different one.