### PR TITLE
Preselect permissions for SQL permission checks

### DIFF
--- a/src/manage_acl.h
+++ b/src/manage_acl.h
@@ -146,7 +146,11 @@ acl_user_has_access_uuid (const char *, const char *, const char *, int);
 
 gchar *
 acl_where_owned_user (const char *, const char *, const char *, const get_data_t *,
-                      int, const gchar *, resource_t, array_t *);
+                      int, const gchar *, resource_t, array_t *, gchar **);
+
+gchar *
+acl_where_owned_with (const char *, const get_data_t *, int, const gchar *, resource_t,
+                      array_t *, gchar **);
 
 gchar *
 acl_where_owned (const char *, const get_data_t *, int, const gchar *, resource_t,

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -5828,7 +5828,7 @@ count2 (const char *type, const get_data_t *get, column_t *select_columns,
         const char *extra_tables, const char *extra_where, int owned)
 {
   int ret;
-  gchar *clause, *owned_clause, *owner_filter, *columns, *filter;
+  gchar *clause, *owned_clause, *owner_filter, *columns, *filter, *with;
   array_t *permissions;
 
   assert (get);
@@ -5854,7 +5854,8 @@ count2 (const char *type, const get_data_t *get, column_t *select_columns,
 
   g_free (filter);
 
-  owned_clause = acl_where_owned (type, get, owned, owner_filter, 0, permissions);
+  owned_clause = acl_where_owned_with (type, get, owned, owner_filter, 0,
+                                       permissions, &with);
 
   g_free (owner_filter);
   array_free (permissions);
@@ -5869,15 +5870,16 @@ count2 (const char *type, const get_data_t *get, column_t *select_columns,
       && (clause == NULL)
       && (extra_where == NULL)
       && (strcmp (owned_clause, " t ()") == 0))
-    ret = sql_int ("SELECT count (*) FROM %ss%s;",
-                   type,
+    ret = sql_int ("%sSELECT count (*) FROM %ss%s;",
+                   with ? with : "", type,
                    get->trash && strcmp (type, "task") ? "_trash" : "");
   else
-    ret = sql_int ("SELECT count (%scount_id)"
+    ret = sql_int ("%sSELECT count (%scount_id)"
                    " FROM (SELECT %ss%s.id AS count_id"
                    "       FROM %ss%s%s"
                    "       WHERE %s"
                    "       %s%s%s%s) AS subquery;",
+                   with ? with : "",
                    distinct ? "DISTINCT " : "",
                    type,
                    get->trash && strcmp (type, "task") ? "_trash" : "",
@@ -5890,6 +5892,7 @@ count2 (const char *type, const get_data_t *get, column_t *select_columns,
                    clause ? ") " : "",
                    extra_where ? extra_where : "");
 
+  g_free (with);
   g_free (columns);
   g_free (owned_clause);
   g_free (clause);


### PR DESCRIPTION
This uses WITH to preselect the users permissions, to prevent Postgres
from accessing the permissions table for every row of a query.

The focus is the results perfomance, so this is only used by the GET iterator
count function and the GET_AGGREGATES equivalent.  Can be extended
to all iterators in the future.