### PR TITLE
Fix loading greenbone-certdata-sync.conf (7.0)

### DIFF
--- a/tools/greenbone-certdata-sync.in
+++ b/tools/greenbone-certdata-sync.in
@@ -106,7 +106,7 @@ fi
 # as well as syslog, add "-s" here.
 LOG_CMD="logger -t $SCRIPT_NAME"
 
-[ -r \"@OPENVAS_SYSCONF_DIR@/greenbone-certdata-sync.conf\" ] && . \"@OPENVAS_SYSCONF_DIR@/greenbone-certdata-sync.conf\"
+[ -r "@OPENVAS_SYSCONF_DIR@/greenbone-certdata-sync.conf" ] && . "@OPENVAS_SYSCONF_DIR@/greenbone-certdata-sync.conf"
 
 CERT_DIR="@OPENVAS_CERT_DATA_DIR@"
 SCAP_DIR="@OPENVAS_SCAP_DATA_DIR@"


### PR DESCRIPTION
The extra backslashes in greenbone-certdata-sync prevented it from loading
additional configuration.

Backport of PR 82, by @ktosiek.