### PR TITLE
Add index reports_by_task

### DIFF
--- a/src/manage_pg.c
+++ b/src/manage_pg.c
@@ -3117,6 +3117,9 @@ create_tables ()
   sql ("SELECT create_index ('report_counts_by_report_and_override',"
        "                     'report_counts', 'report, override');");
 
+  sql ("SELECT create_index ('reports_by_task',"
+       "                     'reports', 'task');");
+
   sql ("SELECT create_index ('tag_resources_by_resource',"
        "                     'tag_resources',"
        "                     'resource_type, resource, resource_location');");

--- a/src/manage_sqlite3.c
+++ b/src/manage_sqlite3.c
@@ -3768,6 +3768,8 @@ create_tables ()
        "  scan_run_status INTEGER, slave_progress, slave_task_uuid,"
        "  slave_uuid, slave_name, slave_host, slave_port, source_iface,"
        "  flags INTEGER);");
+  sql ("CREATE INDEX IF NOT EXISTS reports_by_task"
+       " ON reports (task);");
   sql ("CREATE TABLE IF NOT EXISTS report_counts"
        " (id INTEGER PRIMARY KEY, report INTEGER, user INTEGER,"
        "  severity, count, override, end_time INTEGER, min_qod INTEGER);");


### PR DESCRIPTION
This speeds up the slow task iterator that runs in stop_active_tasks
on startup.

An alternate solution would be to create the iterator by hand in
stop_active_tasks, as the iterator only uses the run status.  But
adding the index is good enough, and it may also help GET_TASKS
get the previous report faster.