### PR TITLE
Update permissions and tags on delete_asset

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -62358,6 +62358,8 @@ delete_asset (const char *asset_id, const char *report_id, int dummy)
         }
 
       sql ("DELETE FROM oss WHERE id = %llu;", asset);
+      permissions_set_orphans ("os", asset, LOCATION_TABLE);
+      tags_set_orphans ("os", asset, LOCATION_TABLE);
       sql_commit ();
 
       return 0;
@@ -62393,6 +62395,8 @@ delete_asset (const char *asset_id, const char *report_id, int dummy)
       sql ("DELETE FROM host_max_severities WHERE host = %llu;", asset);
       sql ("DELETE FROM host_details WHERE host = %llu;", asset);
       sql ("DELETE FROM hosts WHERE id = %llu;", asset);
+      permissions_set_orphans ("host", asset, LOCATION_TABLE);
+      tags_set_orphans ("host", asset, LOCATION_TABLE);
       sql_commit ();
 
       return 0;


### PR DESCRIPTION
When a Host or OS asset is deleted, the associated permissions and tags
are now orphaned.