### PR TITLE
Update permissions and tags on delete_asset

### DIFF
--- a/src/gmp.c
+++ b/src/gmp.c
@@ -11181,7 +11181,7 @@ buffer_overrides_xml (GString *buffer, iterator_t *overrides,
                                         "<count>%i</count>",
                                         tag_count);
 
-              init_resource_tag_iterator (&tags, "note",
+              init_resource_tag_iterator (&tags, "override",
                                           get_iterator_resource (overrides),
                                           1, NULL, 1);
 

--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -62351,6 +62351,8 @@ delete_asset (const char *asset_id, const char *report_id, int dummy)
         }
 
       sql ("DELETE FROM oss WHERE id = %llu;", asset);
+      permissions_set_orphans ("os", asset, LOCATION_TABLE);
+      tags_remove_resource ("os", asset, LOCATION_TABLE);
       sql_commit ();
 
       return 0;
@@ -62386,6 +62388,8 @@ delete_asset (const char *asset_id, const char *report_id, int dummy)
       sql ("DELETE FROM host_max_severities WHERE host = %llu;", asset);
       sql ("DELETE FROM host_details WHERE host = %llu;", asset);
       sql ("DELETE FROM hosts WHERE id = %llu;", asset);
+      permissions_set_orphans ("host", asset, LOCATION_TABLE);
+      tags_remove_resource ("host", asset, LOCATION_TABLE);
       sql_commit ();
 
       return 0;


### PR DESCRIPTION
When a Host or OS asset is deleted, the associated permissions and tags
now have the asset reference removed.