### PR TITLE
Use coverxygen for documentation coverage analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,26 +32,50 @@ jobs:
       - run:
           name: Configure and Compile
           command: mkdir build && cd build/ && cmake -DBACKEND=POSTGRESQL -DCMAKE_BUILD_TYPE=Release .. && make install
-  doc_coverage:
+  gen_xml_doc:
     docker:
-      - image: greenbone/code-metrics-doxy-coverage-debian-stretch
+      - image: greenbone/code-metrics-doxygen-debian-stretch
     steps:
       - checkout
       - run:
           name: Generate documentation (XML)
           command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc-xml 2> ~/doxygen-stderr.txt
-      - run:
-          name: Establish coverage
-          command: ~/doxy-coverage/doxy-coverage.py ~/project/build/doc/generated/xml/ > ~/documentation-coverage.txt
       - store_artifacts:
           path: ~/doxygen-stderr.txt
-      - store_artifacts:
-          path: ~/documentation-coverage.txt
+      - persist_to_workspace:
+          root: ~/project/build/doc/generated/
+          paths:
+            - xml
+  doc_coverage:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Install coverxygen and codecov
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install 'coverxygen>=1.3.1' codecov
+      - run:
+          name: Establish documentation coverage
+          command: |
+            . venv/bin/activate
+            python -m coverxygen --src-dir /root/project --xml-dir /tmp/workspace/xml --output lcov.info
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            . venv/bin/activate
+            codecov -F documentation -X gcov -f lcov.info
 workflows:
   version: 2
   build:
     jobs:
       - build_sqlite
       - build_postgresql
-      - doc_coverage
-
+      - gen_xml_doc
+      - doc_coverage:
+          requires:
+            - gen_xml_doc


### PR DESCRIPTION
This commit modifies the CircleCI configuration to split documentation
generation and documentation coverage analysis.

By using `coverxygen` instead of `doxy-coverage` it also enables support
for submitting the documentation coverage results to `codecov.io`.