### PR TITLE
[7.0] Remove alien_found() call for NSIS/EXE generation

### DIFF
--- a/src/lsc_user.c
+++ b/src/lsc_user.c
@@ -888,12 +888,6 @@ lsc_user_exe_recreate (const gchar *name, const gchar *password,
   gchar *exe_path;
   int ret = -1;
 
-  if (alien_found () == FALSE)
-    {
-      g_warning ("%s: Need \"alien\" to make EXEs\n", __FUNCTION__);
-      return -1;
-    }
-
   /* Create NSIS package. */
 
   if (mkdtemp (exe_dir) == NULL)


### PR DESCRIPTION
EXE generation via NSIS is not using alien at all so just drop this call. The same was also already done in the master branch with the simplification of the .deb and .rpm calls: https://github.com/greenbone/gvm/pull/112

https://github.com/greenbone/gvm/pull/112/files#diff-2009e77ea7710f4ea32dfcde1ca1ff44L896