### PR TITLE
[7.0] Add a CODEOWNERS file for GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default reviewers
+*                 @greenbone/gvm-dev


### PR DESCRIPTION
Backport of https://github.com/greenbone/gvm/pull/92 to the openvas-manager-7.0 branch.