### PR TITLE
Improve SCAP info update performance

### DIFF
--- a/src/gvmd.c
+++ b/src/gvmd.c
@@ -111,6 +111,7 @@
 
 #include "logf.h"
 #include "manage.h"
+#include "manage_sql_secinfo.h"
 #include "scanner.h"
 #include "gmpd.h"
 #include "comm.h"
@@ -1694,6 +1695,7 @@ main (int argc, char** argv)
   static gchar *scanner_key_pub = NULL;
   static gchar *scanner_key_priv = NULL;
   static int schedule_timeout = SCHEDULE_TIMEOUT_DEFAULT;
+  static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
   static gchar *delete_scanner = NULL;
   static gchar *verify_scanner = NULL;
   static gchar *priorities = "NORMAL";
@@ -1764,6 +1766,7 @@ main (int argc, char** argv)
           "Verify scanner <scanner-uuid> and exit.", "<scanner-uuid>" },
         { "delete-scanner", '\0', 0, G_OPTION_ARG_STRING, &delete_scanner, "Delete scanner <scanner-uuid> and exit.", "<scanner-uuid>" },
         { "get-scanners", '\0', 0, G_OPTION_ARG_NONE, &get_scanners, "List scanners and exit.", NULL },
+        { "secinfo-commit-size", '\0', 0, G_OPTION_ARG_INT, &secinfo_commit_size, "During CERT and SCAP sync, commit updates to the database every <number> items, 0 for unlimited, default: " G_STRINGIFY (SECINFO_COMMIT_SIZE_DEFAULT), "<number>" },
         { "schedule-timeout", '\0', 0, G_OPTION_ARG_INT, &schedule_timeout, "Time out tasks that are more than <time> minutes overdue. -1 to disable, 0 for minimum time, default: " G_STRINGIFY (SCHEDULE_TIMEOUT_DEFAULT), "<time>" },
         { "foreground", 'f', 0, G_OPTION_ARG_NONE, &foreground, "Run in foreground.", NULL },
         { "inheritor", '\0', 0, G_OPTION_ARG_STRING, &inheritor, "Have <username> inherit from deleted user.", "<username>" },
@@ -1845,6 +1848,10 @@ main (int argc, char** argv)
   /* Set schedule_timeout */
 
   set_schedule_timeout (schedule_timeout);
+
+  /* Set SecInfo update commit size */
+
+  set_secinfo_commit_size (secinfo_commit_size);
 
   /* Check which type of socket to use. */
 

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -2424,8 +2424,17 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                 {
                   entity_t product;
                   entities_t products;
+                  resource_t cve_rowid;
 
                   products = list->entities;
+
+                  if (first_entity (products))
+                    {
+                      sql_int64 (&cve_rowid,
+                                 "SELECT id FROM cves WHERE uuid='%s';",
+                                 quoted_id);
+                    }
+
                   while ((product = first_entity (products)))
                     {
                       if ((strcmp (entity_name (product), "vuln:product") == 0)
@@ -2446,9 +2455,9 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                quoted_product, quoted_product, time_published,
                                time_modified);
                           sql ("SELECT merge_affected_product"
-                               "        ((SELECT id FROM cves WHERE uuid='%s'),"
+                               "        (%llu,"
                                "         (SELECT id FROM cpes WHERE name='%s'))",
-                               quoted_id, quoted_product);
+                               cve_rowid, quoted_product);
                           transaction_size ++;
                           increment_transaction_size (&transaction_size);
                           g_free (quoted_product);

--- a/src/manage_sql_secinfo.c
+++ b/src/manage_sql_secinfo.c
@@ -54,6 +54,11 @@
 #define G_LOG_DOMAIN "md manage"
 
 
+/* Static variables. */
+
+static int secinfo_commit_size = SECINFO_COMMIT_SIZE_DEFAULT;
+
+
 /* Headers. */
 
 void
@@ -92,6 +97,21 @@ string_replace (const gchar *string, const gchar *to, ...)
     }
   va_end (ap);
   return ret;
+}
+
+/**
+ * @brief Increment transaction size, commit and reset at secinfo_commit_size.
+ *
+ * @param[in,out]  count  Pointer to current size to increment and compare.
+ */
+inline static void
+increment_transaction_size (int* current_size) {
+  if (secinfo_commit_size && (++(*current_size) > secinfo_commit_size))
+    {
+      *current_size = 0;
+      sql_commit ();
+      sql_begin_immediate ();
+    }
 }
 
 
@@ -1379,6 +1399,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
   gsize xml_len;
   GStatBuf state;
   int updated_dfn_cert;
+  int transaction_size = 0;
 
   updated_dfn_cert = 0;
   g_info ("%s: %s", __FUNCTION__, xml_path);
@@ -1505,6 +1526,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                    quoted_title,
                    quoted_summary,
                    cve_refs);
+              increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_summary);
 
@@ -1543,6 +1565,7 @@ update_dfn_xml (const gchar *xml_path, int last_cert_update,
                                    "  '%s')",
                                    quoted_refnum,
                                    quoted_point);
+                              increment_transaction_size (&transaction_size);
                               g_free (quoted_point);
                             }
                           point++;
@@ -1653,6 +1676,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
   gsize xml_len;
   GStatBuf state;
   int updated_cert_bund;
+  int transaction_size = 0;
 
   updated_cert_bund = 0;
   full_path = g_build_filename (GVM_CERT_DATA_DIR, xml_path, NULL);
@@ -1788,6 +1812,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                    quoted_title,
                    quoted_summary,
                    cve_refs);
+              increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_summary);
 
@@ -1813,6 +1838,7 @@ update_bund_xml (const gchar *xml_path, int last_cert_update,
                                "  '%s')",
                                quoted_refnum,
                                quoted_cve);
+                          increment_transaction_size (&transaction_size);
                           g_free (quoted_cve);
                         }
 
@@ -1916,6 +1942,7 @@ update_scap_cpes (int last_scap_update)
   gsize xml_len;
   GStatBuf state;
   int updated_scap_cpes, last_cve_update;
+  int transaction_size = 0;
 
   updated_scap_cpes = 0;
   full_path = g_build_filename (GVM_SCAP_DATA_DIR,
@@ -2079,6 +2106,7 @@ update_scap_cpes (int last_scap_update)
                    quoted_status,
                    deprecated ? deprecated : "NULL",
                    quoted_nvd_id);
+              increment_transaction_size (&transaction_size);
               g_free (quoted_title);
               g_free (quoted_name);
               g_free (quoted_status);
@@ -2123,6 +2151,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
   gsize xml_len;
   GStatBuf state;
   int updated_scap_bund;
+  int transaction_size = 0;
 
   updated_scap_bund = 0;
   full_path = g_build_filename (GVM_SCAP_DATA_DIR, xml_path, NULL);
@@ -2382,6 +2411,7 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                    quoted_integrity_impact,
                    quoted_availability_impact,
                    quoted_software);
+              increment_transaction_size (&transaction_size);
               g_free (quoted_summary);
               g_free (quoted_access_vector);
               g_free (quoted_access_complexity);
@@ -2419,6 +2449,8 @@ update_cve_xml (const gchar *xml_path, int last_scap_update,
                                "        ((SELECT id FROM cves WHERE uuid='%s'),"
                                "         (SELECT id FROM cpes WHERE name='%s'))",
                                quoted_id, quoted_product);
+                          transaction_size ++;
+                          increment_transaction_size (&transaction_size);
                           g_free (quoted_product);
                         }
 
@@ -2763,6 +2795,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
   gsize xml_len;
   GStatBuf state;
   int last_oval_update, file_timestamp;
+  int transaction_size = 0;
 
   /* Setup variables. */
 
@@ -2866,6 +2899,9 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
        "                               WHERE xml_file = '%s');",
        quoted_xml_basename,
        quoted_xml_basename);
+
+  sql_commit();
+  sql_begin_immediate();
 
   oval_oval_definitions_date (entity, &file_timestamp);
 
@@ -3024,7 +3060,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                        quoted_xml_basename,
                        quoted_status,
                        cve_count);
-
+                  increment_transaction_size (&transaction_size);
                   g_free (quoted_id);
                   g_free (quoted_class);
                   g_free (quoted_title);
@@ -3055,6 +3091,7 @@ update_ovaldef_xml (gchar **file_and_date, int last_scap_update,
                                "                 AND ovaldef = ovaldefs.id);",
                                quoted_ref_id,
                                quoted_oval_id);
+                          increment_transaction_size (&transaction_size);
                         }
                       references = next_entities (references);
                     }
@@ -4371,4 +4408,29 @@ manage_sync_scap (sigset_t *sigmask_current)
                 sync_scap,
                 "gvmd: Syncing SCAP",
                 "gvm-sync-scap");
+}
+
+/**
+ * @brief Get the current SecInfo update commit size.
+ *
+ * @return The SecInfo update commit size.
+ */
+int
+get_secinfo_commit_size ()
+{
+  return secinfo_commit_size;
+}
+
+/**
+ * @brief Set the SecInfo update commit size.
+ *
+ * @param new_commit_size The new SecInfo update commit size.
+ */
+void
+set_secinfo_commit_size (int new_commit_size)
+{
+  if (new_commit_size < 0)
+    secinfo_commit_size = 0;
+  else
+    secinfo_commit_size = new_commit_size;
 }

--- a/src/manage_sql_secinfo.h
+++ b/src/manage_sql_secinfo.h
@@ -302,6 +302,11 @@
   "               AS union_sub_6)"                                             \
   " AS allinfo"
 
+/**
+ * @brief Default for secinfo_commit_size.
+ */
+#define SECINFO_COMMIT_SIZE_DEFAULT 0
+
 void
 manage_sync_scap (sigset_t *);
 
@@ -313,5 +318,11 @@ check_scap_db_version ();
 
 int
 check_cert_db_version ();
+
+int
+get_secinfo_commit_size ();
+
+void
+set_secinfo_commit_size (int);
 
 #endif /* not _GVMD_MANAGE_SQL_SECINFO_H */


### PR DESCRIPTION
This PR improves the performance of the SCAP data update with the following:
* a new command line option to split large updates into multiple transaction, which can help with very large updates like the first sync of the CVEs.
* selecting the CVE rowid only once for each one (not every time a affected product is processed) which speeds up large CVE updates by a few seconds.