### PR TITLE
Update scanners on delete_users with inheritor (7.0)

### DIFF
--- a/src/manage_sql.c
+++ b/src/manage_sql.c
@@ -66057,6 +66057,10 @@ delete_user (const char *user_id_arg, const char *name_arg, int ultimate,
            inheritor, user);
       sql ("UPDATE permissions_trash SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
+      sql ("UPDATE scanners SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
+      sql ("UPDATE scanners_trash SET owner = %llu WHERE owner = %llu;",
+           inheritor, user);
       sql ("UPDATE schedules SET owner = %llu WHERE owner = %llu;",
            inheritor, user);
       sql ("UPDATE schedules_trash SET owner = %llu WHERE owner = %llu;",


### PR DESCRIPTION
When deleting a user with an inheritor, the owner of the scanners was
not updated.